### PR TITLE
* Merged in my own BlogCFC Extension.

### DIFF
--- a/client/Application.cfm
+++ b/client/Application.cfm
@@ -38,7 +38,9 @@ The prefix is now dynamic in case 2 people want to run blog.cfc on the same mach
 	<!--- load and init blog --->
 	<cfset application.blog = createObject("component","org.camden.blog.blog").init(blogname)>
 
-	<!--- Do we need to run the installer? --->
+	<cfset application.downloadTracker = createObject("component","org.camden.blog.downloadtracker").init()>
+
+<!--- Do we need to run the installer? --->
 	<cfif application.blog.getProperty("installed") is 0>
 		<cflocation url="./installer/index.cfm?blog=#urlEncodedFormat(blogname)#" addToken="false">
 	</cfif>
@@ -132,13 +134,16 @@ The prefix is now dynamic in case 2 people want to run blog.cfc on the same mach
 	<!--- Do we allow settings in the admin? --->
 	<cfset application.settings = application.blog.getProperty("settings")>
 
+	<cfset application.tableprefix = application.blog.getProperty("tableprefix")>
+
 	<!--- load pod --->
 	<cfset application.pod = createObject("component", "org.camden.blog.pods")>
 
 	<!--- Finally, do a DSN check --->
 	<!--- We end up throwing away this call, but it should be lightweight --->
 	<cfset foo = application.blog.getNameForUser(createUUID())>
-		
+
+
 	<!--- We are initialized --->
 	<cfset application.init = true>
 

--- a/client/admin/stats.cfm
+++ b/client/admin/stats.cfm
@@ -34,8 +34,8 @@
 
 	<cfquery name="getTotalSubscribers" datasource="#dsn#" username="#username#" password="#password#">
 		select	count(email) as totalsubscribers 
-		from	tblblogsubscribers
-		where 	tblblogsubscribers.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
+		from	#application.tableprefix#tblBlogSubscribers
+		where 	#application.tableprefix#tblBlogSubscribers.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
 		and		verified = 1
 	</cfquery>
 
@@ -66,22 +66,22 @@
 	</cfquery>
 	
 	<cfquery name="getTotalComments" datasource="#dsn#" username="#username#" password="#password#">
-		select	count(tblblogcomments.id) as totalcomments
-		from	tblblogcomments, tblblogentries
-		where	tblblogcomments.entryidfk = tblblogentries.id
+		select	count(#application.tableprefix#tblBlogComments.id) as totalcomments
+		from	#application.tableprefix#tblBlogComments, tblblogentries
+		where	#application.tableprefix#tblBlogComments.entryidfk = tblblogentries.id
 		and		tblblogentries.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
 		<cfif application.commentmoderation>
-		and		tblblogcomments.moderated = 1
+		and		#application.tableprefix#tblBlogComments.moderated = 1
 		</cfif>
 	</cfquery>
 	
 	<!--- gets num of entries per category --->
 	<cfquery name="getCategoryCount" datasource="#dsn#" username="#username#" password="#password#">
 		select	categoryid, categoryname, count(categoryidfk) as total
-		from	tblblogcategories, tblblogentriescategories
-		where	tblblogentriescategories.categoryidfk = tblblogcategories.categoryid
-		and		tblblogcategories.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
-		group by tblblogcategories.categoryid, tblblogcategories.categoryname
+		from	#application.tableprefix#tblBlogCategories, #application.tableprefix#tblBlogEntriesCategories
+		where	#application.tableprefix#tblBlogEntriesCategories.categoryidfk = #application.tableprefix#tblBlogCategories.categoryid
+		and		#application.tableprefix#tblBlogCategories.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
+		group by #application.tableprefix#tblBlogCategories.categoryid, #application.tableprefix#tblBlogCategories.categoryname
 		<cfif dbtype is not "msaccess">
 			order by total desc
 		<cfelse>
@@ -93,7 +93,7 @@
 	<cfquery name="topCommentedEntries" datasource="#dsn#" username="#username#" password="#password#">
 		select 
 		<cfif not listFindNoCase("mysql,oracle",dbtype)>top 10 </cfif>
-		tblblogentries.id, tblblogentries.title, count(tblblogcomments.id) as commentcount
+		tblblogentries.id, tblblogentries.title, count(#application.tableprefix#tblBlogComments.id) as commentcount
 		from			tblblogentries, tblblogcomments
 		where			tblblogcomments.entryidfk = tblblogentries.id
 		<cfif dbtype is "oracle">
@@ -117,20 +117,20 @@
 	<cfquery name="topCommentedCategories" datasource="#dsn#" username="#username#" password="#password#">
 		select 
 		<cfif not listFindNoCase("mysql,oracle",dbtype)>top 10 </cfif>
-						tblblogcategories.categoryid, 
-						tblblogcategories.categoryname, 
+						#application.tableprefix#tblBlogCategories.categoryid,
+						#application.tableprefix#tblBlogCategories.categoryname,
 						count(tblblogcomments.id) as commentcount
-		from			tblblogcategories, tblblogcomments, tblblogentriescategories
-		where			tblblogcomments.entryidfk = tblblogentriescategories.entryidfk
+		from			#application.tableprefix#tblBlogCategories, tblblogcomments, #application.tableprefix#tblBlogEntriesCategories
+		where			tblblogcomments.entryidfk = #application.tableprefix#tblBlogEntriesCategories.entryidfk
 		<cfif dbtype is "oracle">
 		and		rownum <= 10
 		</cfif>		
-		and				tblblogentriescategories.categoryidfk = tblblogcategories.categoryid
-		and				tblblogcategories.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
+		and				#application.tableprefix#tblBlogEntriesCategories.categoryidfk = #application.tableprefix#tblBlogCategories.categoryid
+		and				#application.tableprefix#tblBlogCategories.blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
 		<cfif application.commentmoderation>
 		and				tblblogcomments.moderated = 1
 		</cfif>		
-		group by		tblblogcategories.categoryid, tblblogcategories.categoryname
+		group by		#application.tableprefix#tblBlogCategories.categoryid, #application.tableprefix#tblBlogCategories.categoryname
 		<cfif dbtype is not "msaccess">
 			order by	commentcount desc
 		<cfelse>
@@ -143,7 +143,7 @@
 		select		
 		<cfif not listFindNoCase("mysql,oracle",dbtype)>top 10 </cfif>
 					searchterm, count(searchterm) as total
-		from		tblblogsearchstats
+		from		#application.tableprefix#tblBlogSearchStats
 		where		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#blog#">
 		<cfif dbtype is "oracle">
 		and		rownum <= 10

--- a/client/org/camden/blog/blog.cfc
+++ b/client/org/camden/blog/blog.cfc
@@ -36,6 +36,7 @@
 
 		<cfargument name="name" type="string" required="false" default="default" hint="Blog name, defaults to default in blog.ini">
 		<cfargument name="instanceData" type="struct" required="false" hint="Allows you to specify BlogCFC info at runtime.">
+		<cfargument name="BlogDBName" type="string" required="false" hint="I am the blog name in the DB.  If I am specified, I will use the name argument to find the config settings, but the blogDBName to find the database data">
 
 		<cfset var renderDir = "">
 		<cfset var renderCFCs = "">
@@ -83,6 +84,7 @@
 			<cfset instance.itunesAuthor = variables.utils.configParam(variables.cfgFile, arguments.name, "itunesAuthor")>
 			<cfset instance.itunesImage = variables.utils.configParam(variables.cfgFile, arguments.name, "itunesImage")>
 			<cfset instance.itunesExplicit = variables.utils.configParam(variables.cfgFile, arguments.name, "itunesExplicit")>
+			<cfset instance.tableprefix = variables.utils.configParam(variables.cfgFile, arguments.name, "tableprefix")>
 			<cfset instance.usetweetbacks = variables.utils.configParam(variables.cfgFile, arguments.name, "usetweetbacks")>
 			<cfset instance.installed = variables.utils.configParam(variables.cfgFile, arguments.name, "installed")>
 			<cfset instance.saltalgorithm = variables.utils.configParam(variables.cfgFile, arguments.name, "saltalgorithm")>
@@ -91,7 +93,11 @@
 		</cfif>
 
 		<!--- Name the blog --->
-		<cfset instance.name = arguments.name>
+		<cfif IsDefined('arguments.BlogDBName')>
+			<cfset instance.name = arguments.BlogDBName>
+		<cfelse>
+			<cfset instance.name = arguments.name>
+		</cfif>
 
 		<!--- Only real validation we do on instance data. --->
 		<cfif not isValidDBType(instance.blogDBType)>
@@ -153,7 +159,7 @@
 			</cfif>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				insert into tblblogcategories(categoryid,categoryname,categoryalias,blog)
+				insert into #application.tableprefix#tblBlogCategories(categoryid,categoryname,categoryalias,blog)
 				values(
 					<cfqueryparam value="#id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">,
 					<cfqueryparam value="#arguments.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">,
@@ -221,7 +227,7 @@
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		<!--- RBB 11/02/2005:  Added website element --->
-		insert into tblblogcomments(id,entryidfk,name,email,website,comment<cfif instance.blogDBTYPE is "ORACLE">s</cfif>,posted,subscribe,moderated,killcomment,subscribeonly)
+		insert into #application.tableprefix#tblblogcomments(id,entryidfk,name,email,website,comment<cfif instance.blogDBTYPE is "ORACLE">s</cfif>,posted,subscribe,moderated,killcomment,subscribeonly)
 		values(<cfqueryparam value="#newID#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">,
 			   <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">,
 			   <cfqueryparam value="#arguments.name#" maxlength="50">,
@@ -255,7 +261,7 @@
 		<cfif not arguments.subscribe>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			update	tblblogcomments
+			update	#application.tableprefix#tblBlogComments
 			set		subscribe = 0
 			where	entryidfk = <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			and		email = <cfqueryparam value="#arguments.email#" cfsqltype="cf_sql_varchar" maxlength="100">
@@ -289,7 +295,7 @@
 		<cfset var theURL = "">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			insert into tblblogentries(id,title,body,posted
+			insert into #application.tableprefix#tblBlogEntries(id,title,body,posted
 				<cfif len(arguments.morebody)>,morebody</cfif>
 				<cfif len(arguments.alias)>,alias</cfif>
 				,username,blog,allowcomments,enclosure,summary,subtitle,keywords,duration,filesize,mimetype,released,views,mailed)
@@ -394,14 +400,14 @@
 		<!--- First, lets see if this guy is already subscribed. --->
 		<cfquery name="getMe" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	email
-		from	tblblogsubscribers
+		from	#application.tableprefix#tblBlogSubscribers
 		where	email = <cfqueryparam value="#arguments.email#" cfsqltype="cf_sql_varchar" maxlength="50">
 		and		blog = <cfqueryparam value="#instance.name#" cfsqltype="cf_sql_varchar" maxlength="50">
 		</cfquery>
 
 		<cfif getMe.recordCount is 0>
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			insert into tblblogsubscribers(email,
+			insert into #application.tableprefix#tblBlogSubscribers(email,
 			token,
 			blog,
 			verified)
@@ -432,7 +438,7 @@
 		<cflock name="blogcfc.adduser" type="exclusive" timeout="60">
 			<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	username
-			from	tblusers
+			from	#application.tableprefix#tblUsers
 			where	username = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">
 			and		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#instance.name#" maxlength="50">
 			</cfquery>
@@ -442,7 +448,7 @@
 			</cfif>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			insert into tblusers(username, name, password, blog, salt)
+			insert into #application.tableprefix#tblUsers(username, name, password, blog, salt)
 			values(
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">,
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.name#" maxlength="50">,
@@ -460,8 +466,8 @@
 		<cfargument name="commentid" type="uuid" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		update tblblogcomments
-		set	   moderated =
+		update #application.tableprefix#tblBlogComments
+		set	   moderated = 
 			<cfif instance.blogDBType is "MSSQL" or instance.blogDBType is "MSACCESS">
 				<cfqueryparam value="true" cfsqltype="CF_SQL_BIT">
 			<cfelse>
@@ -481,14 +487,14 @@
 
 		<cfquery name="checkEC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryidfk
-			from	tblblogentriescategories
+			from	#application.tableprefix#tblBlogEntriesCategories
 			where	categoryidfk = <cfqueryparam value="#arguments.categoryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			and		entryidfk = <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
 		<cfif entryExists(arguments.entryid) and categoryExists(id=arguments.categoryID) and not checkEC.recordCount>
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				insert into tblblogentriescategories(categoryidfk,entryidfk)
+				insert into #application.tableprefix#tblBlogEntriesCategories(categoryidfk,entryidfk)
 				values(<cfqueryparam value="#arguments.categoryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">,<cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">)
 			</cfquery>
 		</cfif>
@@ -518,7 +524,7 @@
 
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select 	username, password, salt
-			from	tblusers
+			from	#application.tableprefix#tblusers
 			where	username = <cfqueryparam value="#arguments.username#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			and		blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfquery>
@@ -549,8 +555,8 @@
 
 		<cfquery name="checkC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryid
-			from	tblblogcategories
-			where
+			from	#application.tableprefix#tblBlogCategories
+			where	
 				<cfif isDefined("arguments.id")>
 				categoryid = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 				</cfif>
@@ -571,7 +577,7 @@
 		<cfargument name="email" type="string" required="false">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		update	tblblogsubscribers
+		update	#application.tableprefix#tblBlogSubscribers
 		set		verified = 1
 		<cfif structKeyExists(arguments, "token")>
 		where	token = <cfqueryparam cfsqltype="cf_sql_varchar" maxlength="35" value="#arguments.token#">
@@ -589,12 +595,12 @@
 		<cfargument name="id" type="uuid" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogentriescategories
+			delete from #application.tableprefix#tblBlogEntriesCategories
 			where categoryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogcategories
+			delete from #application.tableprefix#tblBlogCategories
 			where categoryid = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
@@ -605,7 +611,7 @@
 		<cfargument name="id" type="uuid" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogcomments
+			delete from #application.tableprefix#tblBlogComments
 			where id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
@@ -629,18 +635,18 @@
 			</cfif>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				delete from tblblogentries
+				delete from #application.tableprefix#tblblogentries
 				where id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 				and	  blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			</cfquery>
 
-			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				delete from tblblogentriescategories
+			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">	
+				delete from #application.tableprefix#tblBlogEntriesCategories
 				where entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfquery>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				delete from tblblogcomments
+				delete from #application.tableprefix#tblblogcomments
 				where entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfquery>
 
@@ -652,16 +658,19 @@
 		<cfargument name="username" type="string" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		delete from tblusers
+		delete from #application.tableprefix#tblUsers
 		where	blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		and		username = <cfqueryparam value="#arguments.username#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfquery>
 
 	</cffunction>
 
+	<!--- JH DotComIt modified slightly to allow a "true" result if the item exists but is not available --->
 	<cffunction name="entryExists" access="private" returnType="boolean" output="false"
 				hint="Returns true or false if an entry exists.">
 		<cfargument name="id" type="uuid" required="true">
+		<cfargument name="isAvailable" type="Boolean" required="false" default="1">
+
 		<cfset var getIt = "">
 
 		<cfif not structKeyExists(variables, "existsCache")>
@@ -673,13 +682,15 @@
 		</cfif>
 		
 		<cfquery name="getIt" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select		tblblogentries.id
-			from		tblblogentries
-			where		tblblogentries.id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
-			and			tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
-			<cfif not isUserInRole("admin")>
-			and			posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
-			and			released = 1
+			select		#application.tableprefix#tblBlogEntries.id
+			from		#application.tableprefix#tblBlogEntries
+			where		#application.tableprefix#tblBlogEntries.id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and			#application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			<cfif (arguments.IsAvailable is 1)>
+				<cfif (not isUserInRole("admin"))>
+                    and			posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
+                    and			released = 1
+				</cfif>
 			</cfif>
 		</cfquery>
 
@@ -790,7 +801,7 @@
 			<cfoutput>
 			<?xml version="1.0" encoding="utf-8"?>
 
-			<rss version="2.0" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns##" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+			<rss version="2.0" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns##" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/">
 
 			<channel>
 			<title>#xmlFormat(instance.blogTitle)##xmlFormat(arguments.additionalTitle)#</title>
@@ -801,11 +812,20 @@
 			<lastBuildDate>{LAST_BUILD_DATE}</lastBuildDate>
 			<generator>BlogCFC</generator>
 			<docs>http://blogs.law.harvard.edu/tech/rss</docs>
-			<managingEditor>#xmlFormat(instance.owneremail)#</managingEditor>
-			<webMaster>#xmlFormat(instance.owneremail)#</webMaster>
+			<!---- JH DotComIt added code to turn e-mails into unitext, removed xmlformat ---->
+			<managingEditor>#(variables.utils.EmailAntiSpam(instance.owneremail))#</managingEditor>
+			<webMaster>#(variables.utils.EmailAntiSpam(instance.owneremail))#</webMaster>
+			<media:copyright>Copyright 2008-#year(now())#, DotComIt LLC</media:copyright>
+			<media:thumbnail url="#xmlFormat(instance.itunesImage)#" />
+            <media:keywords>#xmlFormat(instance.itunesKeywords)#</media:keywords>
+            <media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Software How-To</media:category>
+            <media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Tech News</media:category>
 			<itunes:subtitle>#xmlFormat(instance.itunesSubtitle)#</itunes:subtitle>
 			<itunes:summary>#xmlFormat(instance.itunesSummary)#</itunes:summary>
 			<itunes:category text="Technology" />
+			<itunes:category text="Technology">
+				<itunes:category text="Software How-To" />
+			</itunes:category>
 			<itunes:category text="Technology">
 				<itunes:category text="Podcasting" />
 			</itunes:category>
@@ -849,11 +869,8 @@
 				</cfloop>
 				<pubDate>#dateStr#</pubDate>
 				<guid>#xmlFormat(makeLink(id))#</guid>
-				<!---
-				<author>
-				<name>#xmlFormat(name)#</name>
-				</author>
-				--->
+				<!--- JH, DotComIt Adding this back in; no idea why it was commented out --->
+                <author>#xmlFormat(instance.owneremail)# (#xmlFormat(instance.itunesAuthor)#)</author>
 				<cfif len(enclosure)>
 				<enclosure url="#xmlFormat("#rootURL#/enclosures/#getFileFromPath(enclosure)#")#" length="#filesize#" type="#mimetype#"/>
 				<cfif mimetype IS "audio/mpeg">
@@ -890,15 +907,15 @@
 		<cfset var posted = "">
 
 		<cfif instance.blogDBType is "MSSQL">
-			<cfset posted = "dateAdd(hh, #instance.offset#, tblblogentries.posted)">
+			<cfset posted = "dateAdd(hh, #instance.offset#, #application.tableprefix#tblBlogEntries.posted)">
 		<cfelseif instance.blogDBType is "MSACCESS">
-			<cfset posted = "dateAdd('h', #instance.offset#, tblblogentries.posted)">
+			<cfset posted = "dateAdd('h', #instance.offset#, #application.tableprefix#tblBlogEntries.posted)">
 		<cfelseif instance.blogDBType is "MYSQL">
 			<cfset posted = "date_add(posted, interval #instance.offset# hour)">
 		<cfelseif instance.blogDBType is "ORACLE">
-			<cfset posted = "tblblogentries.posted + (#instance.offset#/24)">
-		</cfif>
-
+			<cfset posted = "#application.tableprefix#tblBlogEntries.posted + (#instance.offset#/24)">
+		</cfif>				
+		
 		<cfquery datasource="#instance.dsn#" name="days" username="#instance.username#" password="#instance.password#">
 			select distinct
 				<cfif instance.blogDBType is "MSSQL">
@@ -910,8 +927,8 @@
 				<cfelseif instance.blogDBType is "ORACLE">
 					to_char(#preserveSingleQuotes(posted)#, 'dd')
 				</cfif> as posted_day
-			from tblblogentries
-			where
+			from #application.tableprefix#tblBlogEntries
+			where 
 				#preserveSingleQuotes(posted)# >= <cfqueryparam value="#dtMonth#" cfsqltype="CF_SQL_TIMESTAMP">
 				and
 				#preserveSingleQuotes(posted)# <= <cfqueryparam value="#dtEndOfMonth#" cfsqltype="CF_SQL_TIMESTAMP">
@@ -930,15 +947,15 @@
 		<cfset var fromYear = year(now()) - arguments.archiveYears />
 		
 		<cfquery name="getMonthlyArchives" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			SELECT MONTH(tblblogentries.posted) AS PreviousMonths, 
-			       YEAR(tblblogentries.posted) AS PreviousYears, 
-				   COUNT(tblblogentries.id) AS entryCount
-			FROM tblblogentries
-			WHERE tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			SELECT MONTH(#application.tableprefix#tblblogentries.posted) AS PreviousMonths,
+			       YEAR(#application.tableprefix#tblblogentries.posted) AS PreviousYears,
+				   COUNT(#application.tableprefix#tblblogentries.id) AS entryCount
+			FROM #application.tableprefix#tblblogentries
+			WHERE #application.tableprefix#tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			<cfif arguments.archiveYears gt 0>
-			AND YEAR(tblblogentries.posted) >= #fromYear#
+			AND YEAR(#application.tableprefix#tblblogentries.posted) >= #fromYear#
 			</cfif>
-			GROUP BY YEAR(tblblogentries.posted), MONTH(tblblogentries.posted) 
+			GROUP BY YEAR(#application.tableprefix#tblblogentries.posted), MONTH(#application.tableprefix#tblblogentries.posted)
 			ORDER BY PreviousYears DESC, PreviousMonths DESC				
 		</cfquery>	
 		
@@ -950,7 +967,7 @@
 
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	id, role, description
-		from	tblblogroles
+		from	#application.tableprefix#tblblogroles
 		</cfquery>
 
 		<cfreturn q>
@@ -980,39 +997,40 @@
 		<cfif instance.blogDBType is "mssql">
 
 			<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				select	tblblogcategories.categoryid, tblblogcategories.categoryname, tblblogcategories.categoryalias, count(tblblogentriescategories.entryidfk) as entryCount
-				from	(tblblogcategories
+				select	#application.tableprefix#tblBlogCategories.categoryid, #application.tableprefix#tblBlogCategories.categoryname, #application.tableprefix#tblBlogCategories.categoryalias, count(#application.tableprefix#tblBlogEntriesCategories.entryidfk) as entryCount
+				from	(#application.tableprefix#tblBlogCategories
 				left outer join
-				tblblogentriescategories ON tblblogcategories.categoryid = tblblogentriescategories.categoryidfk)
-				left join tblblogentries on tblblogentriescategories.entryidfk = tblblogentries.id
-				where	tblblogcategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+				#application.tableprefix#tblBlogEntriesCategories ON #application.tableprefix#tblBlogCategories.categoryid = #application.tableprefix#tblBlogEntriesCategories.categoryidfk)
+				left join #application.tableprefix#tblBlogEntries on #application.tableprefix#tblBlogEntriesCategories.entryidfk = #application.tableprefix#tblBlogEntries.id
+				where	#application.tableprefix#tblBlogCategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 				<!--- Don't allow future posts unless logged in. --->
 				<cfif not isUserInRole("admin")>
-						and isNull(tblblogentries.posted, '1/1/1900') < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#blogNow()#">
-					 	and isNull(tblblogentries.released, 1) = 1
+						and isNull(#application.tableprefix#tblBlogEntries.posted, '1/1/1900') < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#blogNow()#">
+					 	and isNull(#application.tableprefix#tblBlogEntries.released, 1) = 1 
 				</cfif>
-				group by tblblogcategories.categoryid, tblblogcategories.categoryname, tblblogcategories.categoryalias
-				order by tblblogcategories.categoryname
+				group by #application.tableprefix#tblBlogCategories.categoryid, #application.tableprefix#tblBlogCategories.categoryname, #application.tableprefix#tblBlogCategories.categoryalias
+				order by #application.tableprefix#tblBlogCategories.categoryname
 			</cfquery>
 
 		<cfelse>
 
 			<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select	tblblogcategories.categoryid, tblblogcategories.categoryname, tblblogcategories.categoryalias
-			from	tblblogcategories
-			where	tblblogcategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
-			order by tblblogcategories.categoryname
+			select	#application.tableprefix#tblBlogCategories.categoryid, #application.tableprefix#tblBlogCategories.categoryname, 
+					#application.tableprefix#tblBlogCategories.categoryalias
+			from	#application.tableprefix#tblBlogCategories
+			where	#application.tableprefix#tblBlogCategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			order by #application.tableprefix#tblBlogCategories.categoryname
 			</cfquery>
 
 			<cfset queryAddColumn(getC, "entrycount", arrayNew(1))>
 
 			<cfloop query="getC">
 				<cfquery name="getTotal" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				select	count(tblblogentriescategories.entryidfk) as total
-				from	tblblogentriescategories, tblblogentries
-				where	tblblogentriescategories.categoryidfk = <cfqueryparam value="#categoryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
-				and    tblblogentriescategories.entryidfk = tblblogentries.id
-				and    tblblogentries.released = 1
+				select	count(#application.tableprefix#tblBlogEntriescategories.entryidfk) as total
+				from	#application.tableprefix#tblBlogEntriescategories, #application.tableprefix#tblBlogEntries
+				where	#application.tableprefix#tblBlogEntriescategories.categoryidfk = <cfqueryparam value="#categoryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+				and    #application.tableprefix#tblBlogEntriescategories.entryidfk = #application.tableprefix#tblBlogEntries.id
+				and    #application.tableprefix#tblBlogEntries.released = 1				
 				</cfquery>
 				<cfif getTotal.recordCount>
 					<cfset querySetCell(getC, "entrycount", getTotal.total, currentRow)>
@@ -1037,10 +1055,10 @@
 
 		<!--- updated "variables.dsn" to "instance.dsn" (DS 8/22/06) --->
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select	tblblogcategories.categoryID, tblblogcategories.categoryname
-			from	tblblogcategories, tblblogentriescategories
-			where	tblblogcategories.categoryID = tblblogentriescategories.categoryidfk
-			and		tblblogentriescategories.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			select	#application.tableprefix#tblBlogCategories.categoryID, #application.tableprefix#tblBlogCategories.categoryname
+			from	#application.tableprefix#tblBlogCategories, #application.tableprefix#tblBlogEntriescategories
+			where	#application.tableprefix#tblBlogCategories.categoryID = #application.tableprefix#tblBlogEntriescategories.categoryidfk
+			and		#application.tableprefix#tblBlogEntriescategories.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 		<cfreturn getC>
 
@@ -1052,7 +1070,7 @@
 
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryname, categoryalias
-			from	tblblogcategories
+			from	#application.tableprefix#tblBlogCategories
 			where	categoryid = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			and		blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfquery>
@@ -1071,7 +1089,7 @@
 
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryid
-			from	tblblogcategories
+			from	#application.tableprefix#tblBlogCategories
 			where	categoryalias = <cfqueryparam value="#arguments.alias#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			and		blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfquery>
@@ -1087,7 +1105,7 @@
 
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryid
-			from	tblblogcategories
+			from	#application.tableprefix#tblBlogCategories
 			where	categoryname = <cfqueryparam value="#arguments.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			and		blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfquery>
@@ -1103,7 +1121,7 @@
 
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select		id, entryidfk, name, email, website, comment<cfif instance.blogDBTYPE is "ORACLE">s</cfif>, posted, subscribe, moderated, killcomment
-			from		tblblogcomments
+			from		#application.tableprefix#tblBlogComments
 			where		id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
@@ -1125,7 +1143,7 @@
 				
 		<cfquery name="getCommentCount" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select count(id) as commentCount
-			from 	tblblogcomments
+			from 	#application.tableprefix#tblblogcomments
 			where	entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 
 			<cfif instance.moderate>
@@ -1157,34 +1175,34 @@
 
 		<!--- RBB 11/02/2005: Added website to query --->
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select		tblblogcomments.id, tblblogcomments.name, tblblogcomments.email, tblblogcomments.website,
-						<cfif instance.blogDBTYPE is NOT "ORACLE">tblblogcomments.comment<cfelse>to_char(tblblogcomments.comments) as comments</cfif>, tblblogcomments.posted, tblblogcomments.subscribe, tblblogentries.title as entrytitle, tblblogcomments.entryidfk
-			from		tblblogcomments, tblblogentries
-			where		tblblogcomments.entryidfk = tblblogentries.id
+			select		#application.tableprefix#tblBlogComments.id, #application.tableprefix#tblBlogComments.name, #application.tableprefix#tblBlogComments.email, #application.tableprefix#tblBlogComments.website, 
+						<cfif instance.blogDBTYPE is NOT "ORACLE">#application.tableprefix#tblBlogComments.comment<cfelse>to_char(#application.tableprefix#tblBlogComments.comments) as comments</cfif>, #application.tableprefix#tblBlogComments.posted, #application.tableprefix#tblBlogComments.subscribe, #application.tableprefix#tblBlogEntries.title as entrytitle, #application.tableprefix#tblBlogComments.entryidfk
+			from		#application.tableprefix#tblBlogComments, #application.tableprefix#tblBlogEntries
+			where		#application.tableprefix#tblBlogComments.entryidfk = #application.tableprefix#tblBlogEntries.id
 			<cfif structKeyExists(arguments, "search")>
 			and
 						(
 						<cfif instance.blogDBTYpe is not "ORACLE">
-						tblblogcomments.comment
+						#application.tableprefix#tblBlogComments.comment
 						<cfelse>
 						comments
 						</cfif> like <cfqueryparam cfsqltype="cf_sql_varchar" value="%#arguments.search#%">
 						or
-						tblblogcomments.name like <cfqueryparam cfsqltype="cf_sql_varchar" value="%#arguments.search#%">
+						#application.tableprefix#tblBlogComments.name like <cfqueryparam cfsqltype="cf_sql_varchar" value="%#arguments.search#%">
 						)
 			</cfif>
 			<cfif structKeyExists(arguments, "id")>
-			and			tblblogcomments.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and			#application.tableprefix#tblBlogComments.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfif>
-			and			tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			and			#application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			<!--- added 12/5/2006 by Trent Richardson --->
 			<cfif instance.moderate>
-				and tblblogcomments.moderated = 1
+				and #application.tableprefix#tblBlogComments.moderated = 1 
 			</cfif>
 			<cfif not arguments.includesubscribers>
 			and (subscribeonly = 0 or subscribeonly is null)
 			</cfif>
-			order by	tblblogcomments.posted #arguments.sortdir#
+			order by	#application.tableprefix#tblBlogComments.posted #arguments.sortdir#
 		</cfquery>
 
 		<!--- DS 8/22/06: if this is oracle, do a q of q to return the data with column named "comment" --->
@@ -1208,42 +1226,44 @@
 				hint="Returns one particular entry.">
 		<cfargument name="id" type="uuid" required="true">
 		<cfargument name="dontlog" type="boolean" required="false" default="false">
+		<cfargument name="IsAvailable" type="boolean" required="false" default="true">
+
 		<cfset var getIt = "">
 		<cfset var s = structNew()>
 		<cfset var col = "">
 		<cfset var getCategories = "">
 
-		<cfif not entryExists(arguments.id)>
+		<cfif not entryExists(arguments.id,arguments.IsAvailable)>
 			<cfset variables.utils.throw("#arguments.id# does not exist.")>
 		</cfif>
 
 		<cfquery name="getIt" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select		tblblogentries.id, tblblogentries.title,
+			select		#application.tableprefix#tblBlogEntries.id, #application.tableprefix#tblBlogEntries.title, 
 						<!--- Handle offset --->
 						<cfif instance.blogDBType is "MSACCESS">
-						dateAdd('h', #instance.offset#, tblblogentries.posted) as posted,
+						dateAdd('h', #instance.offset#, #application.tableprefix#tblBlogEntries.posted) as posted, 
 						<cfelseif instance.blogDBType is "MSSQL">
-						dateAdd(hh, #instance.offset#, tblblogentries.posted) as posted,
+						dateAdd(hh, #instance.offset#, #application.tableprefix#tblBlogEntries.posted) as posted, 
 						<cfelseif instance.blogDBType is "ORACLE">
-						tblblogentries.posted + (#instance.offset#/24) as posted,
+						#application.tableprefix#tblBlogEntries.posted + (#instance.offset#/24) as posted,
 						<cfelse>
-						date_add(posted, interval #instance.offset# hour) as posted,
+						date_add(posted, interval #instance.offset# hour) as posted, 
 						</cfif>
-						tblblogentries.body,
-						tblblogentries.morebody, tblblogentries.alias, tblusers.name, tblblogentries.allowcomments,
-						tblblogentries.enclosure, tblblogentries.filesize, tblblogentries.mimetype, tblblogentries.released, tblblogentries.mailed,
-						tblblogentries.summary, tblblogentries.keywords, tblblogentries.subtitle, tblblogentries.duration
-			from		tblblogentries, tblusers
-			where		tblblogentries.id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
-			and			tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
-			and			tblblogentries.username = tblusers.username
+						#application.tableprefix#tblBlogEntries.body, 
+						#application.tableprefix#tblBlogEntries.morebody, #application.tableprefix#tblBlogEntries.alias, #application.tableprefix#tblUsers.name, #application.tableprefix#tblBlogEntries.allowcomments,
+						#application.tableprefix#tblBlogEntries.enclosure, #application.tableprefix#tblBlogEntries.filesize, #application.tableprefix#tblBlogEntries.mimetype, #application.tableprefix#tblBlogEntries.released, #application.tableprefix#tblBlogEntries.mailed,
+						#application.tableprefix#tblBlogEntries.summary, #application.tableprefix#tblBlogEntries.keywords, #application.tableprefix#tblBlogEntries.subtitle, #application.tableprefix#tblBlogEntries.duration
+			from		#application.tableprefix#tblBlogEntries, #application.tableprefix#tblUsers
+			where		#application.tableprefix#tblBlogEntries.id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and			#application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			and			#application.tableprefix#tblBlogEntries.username = #application.tableprefix#tblUsers.username
 		</cfquery>
 
 		<cfquery name="getCategories" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	categoryid,categoryname
-			from	tblblogcategories, tblblogentriescategories
-			where	tblblogentriescategories.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
-			and		tblblogentriescategories.categoryidfk = tblblogcategories.categoryid
+			from	#application.tableprefix#tblBlogCategories, #application.tableprefix#tblBlogEntriescategories
+			where	#application.tableprefix#tblBlogEntriescategories.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and		#application.tableprefix#tblBlogEntriescategories.categoryidfk = #application.tableprefix#tblBlogCategories.categoryid
 		</cfquery>
 
 		<cfloop index="col" list="#getIt.columnList#">
@@ -1258,7 +1278,7 @@
 		<!--- Handle view --->
 		<cfif not arguments.dontlog>
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			update	tblblogentries
+			update	#application.tableprefix#tblBlogEntries
 			set		views = views + 1
 			where	id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfquery>
@@ -1355,26 +1375,26 @@
 
 		<!--- I get JUST the ids --->
 		<cfquery name="getIds" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		select	tblblogentries.id
-		from	tblblogentries, tblusers
-			<cfif structKeyExists(arguments.params,"byCat")>,tblblogentriescategories</cfif>
+		select	#application.tableprefix#tblblogentries.id
+		from	#application.tableprefix#tblblogentries, #application.tableprefix#tblusers
+			<cfif structKeyExists(arguments.params,"byCat")>,#application.tableprefix#tblblogentriescategories</cfif>
 			where		1=1
-						and tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
-						and tblblogentries.username = tblusers.username
+						and #application.tableprefix#tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+						and #application.tableprefix#tblblogentries.username = #application.tableprefix#tblusers.username
 						<!--- fix suggested by William Steiner --->
-						and	tblblogentries.blog = tblusers.blog
+						and	#application.tableprefix#tblblogentries.blog = #application.tableprefix#tblusers.blog
 			<cfif structKeyExists(arguments.params,"lastXDays")>
-				and tblblogentries.posted >= <cfqueryparam value="#dateAdd("d",-1*arguments.params.lastXDays,blogNow())#" cfsqltype="CF_SQL_DATE">
+				and #application.tableprefix#tblblogentries.posted >= <cfqueryparam value="#dateAdd("d",-1*arguments.params.lastXDays,blogNow())#" cfsqltype="CF_SQL_DATE">
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byDay")>
 				<cfif instance.blogDBType is "MSSQL">
-					and day(dateAdd(hh, #instance.offset#, tblblogentries.posted))
+					and day(dateAdd(hh, #instance.offset#, #application.tableprefix#tblblogentries.posted)) 
 				<cfelseif  instance.blogDBType is "MSACCESS">
-					and day(dateAdd('h', #instance.offset#, tblblogentries.posted))
+					and day(dateAdd('h', #instance.offset#, #application.tableprefix#tblblogentries.posted)) 
 				<cfelseif instance.blogDBType is "MYSQL">
 					and dayOfMonth(date_add(posted, interval #instance.offset# hour))
 				<cfelseif instance.blogDBType is "ORACLE">
-					and to_number(to_char(tblblogentries.posted + (#instance.offset#/24), 'dd'))
+					and to_number(to_char(#application.tableprefix#tblblogentries.posted + (#instance.offset#/24), 'dd'))	
 				</cfif>
 					<cfif instance.blogDBType is not "ORACLE">
 					= <cfqueryparam value="#arguments.params.byDay#" cfsqltype="CF_SQL_NUMERIC">
@@ -1385,56 +1405,56 @@
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byMonth")>
 				<cfif instance.blogDBType is "MSSQL">
-					and month(dateAdd(hh, #instance.offset#, tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byMonth#" cfsqltype="CF_SQL_NUMERIC">
+					and month(dateAdd(hh, #instance.offset#, #application.tableprefix#tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byMonth#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "MSACCESS">
-					and month(dateAdd('h', #instance.offset#, tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byMonth#" cfsqltype="CF_SQL_NUMERIC">
+					and month(dateAdd('h', #instance.offset#, #application.tableprefix#tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byMonth#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "MYSQL">
 					and month(date_add(posted, interval #instance.offset# hour)) = <cfqueryparam value="#arguments.params.byMonth#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "ORACLE">
-					and to_number(to_char(tblblogentries.posted + (#instance.offset#/24), 'MM')) = <cfqueryparam cfsqltype="cf_sql_integer" value="#arguments.params.byMonth#">
+					and to_number(to_char(#application.tableprefix#tblblogentries.posted + (#instance.offset#/24), 'MM')) = <cfqueryparam cfsqltype="cf_sql_integer" value="#arguments.params.byMonth#">	
 				</cfif>
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byYear")>
 				<cfif instance.blogDBType is "MSSQL">
-					and year(dateAdd(hh, #instance.offset#, tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byYear#" cfsqltype="CF_SQL_NUMERIC">
+					and year(dateAdd(hh, #instance.offset#, #application.tableprefix#tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byYear#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "MSACCESS">
-					and year(dateAdd('h', #instance.offset#, tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byYear#" cfsqltype="CF_SQL_NUMERIC">
+					and year(dateAdd('h', #instance.offset#, #application.tableprefix#tblblogentries.posted)) = <cfqueryparam value="#arguments.params.byYear#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "MYSQL">
 					and year(date_add(posted, interval #instance.offset# hour)) = <cfqueryparam value="#arguments.params.byYear#" cfsqltype="CF_SQL_NUMERIC">
 				<cfelseif instance.blogDBType is "ORACLE">
-					and to_number(to_char(tblblogentries.posted + (#instance.offset#/24), 'YYYY')) = <cfqueryparam cfsqltype="cf_sql_integer" value="#arguments.params.byYear#">
-				</cfif>
+					and to_number(to_char(#application.tableprefix#tblblogentries.posted + (#instance.offset#/24), 'YYYY')) = <cfqueryparam cfsqltype="cf_sql_integer" value="#arguments.params.byYear#">	
+				</cfif>					
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byTitle")>
-				and tblblogentries.title = <cfqueryparam value="#arguments.params.byTitle#" cfsqltype="CF_SQL_VARCHAR" maxlength="100">
+				and #application.tableprefix#tblblogentries.title = <cfqueryparam value="#arguments.params.byTitle#" cfsqltype="CF_SQL_VARCHAR" maxlength="100">
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byCat")>
-				and tblblogentriescategories.entryidfk = tblblogentries.id
-				and tblblogentriescategories.categoryidfk in (<cfqueryparam value="#arguments.params.byCat#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" list=true>)
+				and #application.tableprefix#tblblogentriescategories.entryidfk = #application.tableprefix#tblblogentries.id
+				and #application.tableprefix#tblblogentriescategories.categoryidfk in (<cfqueryparam value="#arguments.params.byCat#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" list=true>)
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byPosted")>
-				and tblblogentries.username =  <cfqueryparam value="#arguments.params.byPosted#" cfsqltype="CF_SQL_VARCHAR" maxlength="50" list=true>
+				and #application.tableprefix#tblblogentries.username =  <cfqueryparam value="#arguments.params.byPosted#" cfsqltype="CF_SQL_VARCHAR" maxlength="50" list=true>
 			</cfif>				
 			<cfif structKeyExists(arguments.params,"searchTerms")>
 				<cfif not structKeyExists(arguments.params, "dontlogsearch")>
 					<cfset logSearch(arguments.params.searchTerms)>
 				</cfif>
 				<cfif instance.blogDBType is not "ORACLE">
-					and (tblblogentries.title like '%#arguments.params.searchTerms#%' OR tblblogentries.body like '%#arguments.params.searchTerms#%' or tblblogentries.morebody like '%#arguments.params.searchTerms#%')
+					and (#application.tableprefix#tblblogentries.title like '%#arguments.params.searchTerms#%' OR #application.tableprefix#tblblogentries.body like '%#arguments.params.searchTerms#%' or #application.tableprefix#tblblogentries.morebody like '%#arguments.params.searchTerms#%')
 				<cfelse>
-				and (lower(tblblogentries.title) like '%#lcase(arguments.params.searchTerms)#%' OR lower(tblblogentries.body) like '%#lcase(arguments.params.searchTerms)#%' or lower(tblblogentries.morebody) like '%#lcase(arguments.params.searchTerms)#%')
+				and (lower(#application.tableprefix#tblblogentries.title) like '%#lcase(arguments.params.searchTerms)#%' OR lower(#application.tableprefix#tblblogentries.body) like '%#lcase(arguments.params.searchTerms)#%' or lower(#application.tableprefix#tblblogentries.morebody) like '%#lcase(arguments.params.searchTerms)#%')
 				</cfif>
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byEntry")>
-				and tblblogentries.id = <cfqueryparam value="#arguments.params.byEntry#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+				and #application.tableprefix#tblblogentries.id = <cfqueryparam value="#arguments.params.byEntry#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfif>
 			<cfif structKeyExists(arguments.params,"byAlias")>
-				and tblblogentries.alias = <cfqueryparam value="#left(arguments.params.byAlias,100)#" cfsqltype="CF_SQL_VARCHAR" maxlength="100">
+				and #application.tableprefix#tblblogentries.alias = <cfqueryparam value="#arguments.params.byAlias#" cfsqltype="CF_SQL_VARCHAR" maxlength="100">
 			</cfif>
 			<!--- Don't allow future posts unless logged in. --->
 			<cfif not isUserInRole("admin") or (structKeyExists(arguments.params, "releasedonly") and arguments.params.releasedonly)>
 				<cfif instance.blogDBType IS "ORACLE">
-					 and			to_char(tblblogentries.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#">
+					 and			to_char(#application.tableprefix#tblblogentries.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#"> 
 				<cfelse>
 					and			posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
 				</cfif>
@@ -1445,7 +1465,7 @@
 			and	released = <cfqueryparam cfsqltype="cf_sql_bit" value="#arguments.params.released#">
 			</cfif>
 
-			order by 	tblblogentries.#arguments.params.orderBy# #arguments.params.orderByDir#
+			order by 	#application.tableprefix#tblblogentries.#arguments.params.orderBy# #arguments.params.orderByDir#
 		</cfquery>
 
 		<!--- we now have a query from row 1 to our max, we need to get a 'page' of IDs --->
@@ -1464,40 +1484,37 @@
 		<!--- I now get the full info --->
 		<cfquery name="getEm" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#" maxrows="#arguments.params.maxEntries+arguments.params.startRow-1#">
 		<!--- DS 8/22/06: added Oracle pseudo top n code --->
-			select
-					tblblogentries.id, tblblogentries.title,
-					tblblogentries.alias,
+			select		
+					#application.tableprefix#tblblogentries.id, #application.tableprefix#tblblogentries.title, 
+					#application.tableprefix#tblblogentries.alias, 
 					<!--- Handle offset --->
 					<cfif instance.blogDBType is "MSACCESS">
-						dateAdd('h', #instance.offset#, tblblogentries.posted) as posted,
+						dateAdd('h', #instance.offset#, #application.tableprefix#tblblogentries.posted) as posted, 
 					<cfelseif instance.blogDBType is "MSSQL">
-						dateAdd(hh, #instance.offset#, tblblogentries.posted) as posted,
+						dateAdd(hh, #instance.offset#, #application.tableprefix#tblblogentries.posted) as posted, 
 					<cfelseif instance.blogDBType is "ORACLE">
-						tblblogentries.posted + (#instance.offset#/24) as posted,
+						#application.tableprefix#tblblogentries.posted + (#instance.offset#/24) as posted,	
 					<cfelse>
 					date_add(posted, interval #instance.offset# hour) as posted,
 					</cfif>
-					tblusers.name, tblblogentries.allowcomments,
-					tblblogentries.enclosure, tblblogentries.filesize, tblblogentries.mimetype, tblblogentries.released, tblblogentries.views,
-					tblblogentries.summary, tblblogentries.subtitle, tblblogentries.keywords, tblblogentries.duration
-				<cfif arguments.params.mode is "full">, tblblogentries.body, tblblogentries.morebody</cfif>
-			from	tblblogentries, tblusers
-			where
-				tblblogentries.id in (<cfqueryparam cfsqltype="cf_sql_varchar" list="true" value="#pageIdList#">)
-						and tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
-						and tblblogentries.username = tblusers.username
-						<!--- fix by Amy Wilson --->
-						and	tblblogentries.blog = tblusers.blog
-
-			order by 	tblblogentries.#arguments.params.orderBy# #arguments.params.orderByDir#
+					#application.tableprefix#tblusers.name, #application.tableprefix#tblblogentries.allowcomments,
+					#application.tableprefix#tblblogentries.enclosure, #application.tableprefix#tblblogentries.filesize, #application.tableprefix#tblblogentries.mimetype, #application.tableprefix#tblblogentries.released, #application.tableprefix#tblblogentries.views,
+					#application.tableprefix#tblblogentries.summary, #application.tableprefix#tblblogentries.subtitle, #application.tableprefix#tblblogentries.keywords, #application.tableprefix#tblblogentries.duration
+				<cfif arguments.params.mode is "full">, #application.tableprefix#tblblogentries.body, #application.tableprefix#tblblogentries.morebody</cfif>
+			from	#application.tableprefix#tblblogentries, #application.tableprefix#tblusers
+			where		
+				#application.tableprefix#tblblogentries.id in (<cfqueryparam cfsqltype="cf_sql_varchar" list="true" value="#pageIdList#">)
+						and #application.tableprefix#tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+						and #application.tableprefix#tblblogentries.username = #application.tableprefix#tblusers.username
+			order by 	#application.tableprefix#tblblogentries.#arguments.params.orderBy# #arguments.params.orderByDir#
 		</cfquery>
 
 		<cfif arguments.params.mode is "full" and getEm.recordCount>
 			<cfset queryAddColumn(getEm,"commentCount",arrayNew(1))>
 			<cfquery name="getComments" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 				select count(id) as commentCount, entryidfk
-				from 	tblblogcomments
-				where	entryidfk in (<cfqueryparam value="#valueList(getEm.id)#" cfsqltype="CF_SQL_VARCHAR" list="Yes">)
+				from 	#application.tableprefix#tblblogcomments
+				where	entryidfk in (<cfqueryparam value="#valueList(getEm.id)#" cfsqltype="CF_SQL_VARCHAR" list="Yes">)	
 				<!--- added 12/5/2006 by Trent Richardson --->
 				<cfif instance.moderate>
 					and moderated = 1
@@ -1518,9 +1535,9 @@
 			<cfloop query="getEm">
 				<cfquery name="getCategories" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 					select	categoryid,categoryname
-					from	tblblogcategories, tblblogentriescategories
-					where	tblblogentriescategories.entryidfk = <cfqueryparam value="#getEm.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
-					and		tblblogentriescategories.categoryidfk = tblblogcategories.categoryid
+					from	#application.tableprefix#tblblogcategories, #application.tableprefix#tblblogentriescategories
+					where	#application.tableprefix#tblblogentriescategories.entryidfk = <cfqueryparam value="#getEm.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+					and		#application.tableprefix#tblblogentriescategories.categoryidfk = #application.tableprefix#tblblogcategories.categoryid
 				</cfquery>
 				<!---
 				<cfset querySetCell(getEm,"categoryids",valueList(getCategories.categoryID),currentRow)>
@@ -1551,7 +1568,7 @@
 		
 	    <cfquery name="getPostedDate" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
       		select posted
-      		from tblblogentries
+      		from #application.tableprefix#tblblogentries
       		where id = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" />
     	</cfquery>
     	
@@ -1565,7 +1582,7 @@
 
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	name
-		from	tblusers
+		from	#application.tableprefix#tblUsers
 		where	username = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">
 		</cfquery>
 
@@ -1576,8 +1593,8 @@
 				hint="Returns the number of unmodderated comments for a specific blog entry.">
 		<cfset var getUnmoderated = "" />
 		<cfquery name="getUnmoderated" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select count(c.moderated) as unmoderated
-			from tblblogcomments c, tblblogentries e
+			select count(c.moderated) as unmoderated 
+			from #application.tableprefix#tblBlogComments c, #application.tableprefix#tblBlogEntries e
 			where c.moderated=0
 			and	 e.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			and c.entryidfk = e.id
@@ -1634,8 +1651,8 @@
 		<cfelse>
 		    date_add(c.posted, interval #instance.offset# hour) as posted
 		</cfif>
-		from tblblogcomments c
-		inner join tblblogentries e on c.entryidfk = e.id
+		from #application.tableprefix#tblBlogComments c
+		inner join #application.tableprefix#tblBlogEntries e on c.entryidfk = e.id
 		where	 blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		<!--- added 12/5/2006 by Trent Richardson --->
 		<cfif instance.moderate>
@@ -1692,44 +1709,44 @@
 		</cfif>
 	    <cfquery name="getRelatedIds" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 	      select distinct relatedid
-	      from tblblogentriesrelated
+	      from #application.tableprefix#tblBlogEntriesrelated
 	      where entryid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" />
 
 	      <cfif bDislayBackwardRelations>
 	      union
 
 	      select distinct entryid as relatedid
-	      from tblblogentriesrelated
+	      from #application.tableprefix#tblBlogEntriesrelated
 	      where relatedid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" />
 	      </cfif>
 	    </cfquery>
 	    <cfloop query="getRelatedIds">
 		  <cfquery name="getThisRelatedEntry" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select
-				tblblogentries.id,
-				tblblogentries.title,
-				tblblogentries.posted,
-				tblblogentries.alias,
-				tblblogcategories.categoryname
+				#application.tableprefix#tblBlogEntries.id,
+				#application.tableprefix#tblBlogEntries.title,
+				#application.tableprefix#tblBlogEntries.posted,
+				#application.tableprefix#tblBlogEntries.alias,
+				#application.tableprefix#tblBlogCategories.categoryname
 			from
-				(tblblogcategories
-				inner join tblblogentriescategories on
-					tblblogcategories.categoryid = tblblogentriescategories.categoryidfk)
-				inner join tblblogentries on
-					tblblogentriescategories.entryidfk = tblblogentries.id
-	        where tblblogentries.id = <cfqueryparam value="#getrelatedids.relatedid#" cfsqltype="cf_sql_varchar" maxlength="35" />
-	        and   tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="cf_sql_varchar" maxlength="255">
+				(#application.tableprefix#tblBlogCategories 
+				inner join #application.tableprefix#tblBlogEntriescategories on 
+					#application.tableprefix#tblBlogCategories.categoryid = #application.tableprefix#tblBlogEntriescategories.categoryidfk)
+				inner join #application.tableprefix#tblBlogEntries on 
+					#application.tableprefix#tblBlogEntriescategories.entryidfk = #application.tableprefix#tblBlogEntries.id
+	        where #application.tableprefix#tblBlogEntries.id = <cfqueryparam value="#getrelatedids.relatedid#" cfsqltype="cf_sql_varchar" maxlength="35" />
+	        and   #application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="cf_sql_varchar" maxlength="255">
 	        <cfif bdislayfuturelinks is false>
 				<cfif instance.blogDBType is not "ORACLE">
-				and tblblogentries.posted <= #createodbcdatetime(postedDate)#
+				and #application.tableprefix#tblblogentries.posted <= #createodbcdatetime(postedDate)#
 				<cfelse>
-				and tblblogentries.posted <= <cfqueryparam cfsqltype="cf_sql_timestamp" value="#postedDate#">
+				and #application.tableprefix#tblblogentries.posted <= <cfqueryparam cfsqltype="cf_sql_timestamp" value="#postedDate#">
 				</cfif>
 	        </cfif>
 
 			<cfif not arguments.bDisplayForAdmin>
 				<cfif instance.blogDBType IS "ORACLE">
-					 and			to_char(tblblogentries.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#">
+					 and			to_char(#application.tableprefix#tblblogentries.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#">
 				<cfelse>
 					and			posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
 				</cfif>
@@ -1780,29 +1797,29 @@
 		
 		<cfquery name="getRelatedBlogEntryCount" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			SELECT count(entryId) AS relatedEntryCount
-				FROM tblblogentriesrelated, tblblogentries
-				WHERE tblblogentriesrelated.entryID = tblblogentries.id
-				AND (tblblogentriesrelated.entryid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+				FROM #application.tableprefix#tblblogentriesrelated, #application.tableprefix#tblblogentries
+				WHERE #application.tableprefix#tblblogentriesrelated.entryID = tblblogentries.id
+				AND (#application.tableprefix#tblblogentriesrelated.entryid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			<cfif arguments.bDislayBackwardRelations>
-				OR tblblogentriesrelated.relatedid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" />
+				OR #application.tableprefix#tblblogentriesrelated.relatedid = <cfqueryparam value="#arguments.entryId#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" />
 			</cfif>					
 				)
 	        <cfif bdislayfuturelinks is false>
 				<cfif instance.blogDBType is not "ORACLE">
-				AND tblblogentries.posted <= #createodbcdatetime(postedDate)#
+				AND #application.tableprefix#tblblogentries.posted <= #createodbcdatetime(postedDate)#
 				<cfelse>
-				AND tblblogentries.posted <= <cfqueryparam cfsqltype="cf_sql_timestamp" value="#postedDate#">
+				AND #application.tableprefix#tblblogentries.posted <= <cfqueryparam cfsqltype="cf_sql_timestamp" value="#postedDate#">
 				</cfif>
 	        </cfif>				
 				
 			<cfif arguments.bDisplayForAdmin is false>	
 				<cfif instance.blogDBType IS "ORACLE">
-			 		AND	to_char(tblblogentries.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#">
+			 		AND	to_char(#application.tableprefix#.posted + (#instance.offset#/24), 'YYYY-MM-DD HH24:MI:SS') <= <cfqueryparam cfsqltype="cf_sql_varchar" value="#dateformat(now(), 'YYYY-MM-DD')# #timeformat(now(), 'HH:mm:ss')#">
 				<cfelse>
-					AND	tblblogentries.posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
+					AND	#application.tableprefix#tblblogentries.posted < <cfqueryparam cfsqltype="cf_sql_timestamp" value="#now()#">
 				</cfif>
 			</cfif>			
-				AND	tblblogentries.released = 1
+				AND	#application.tableprefix#tblblogentries.released = 1
 		</cfquery>
 		
 		<cfreturn getRelatedBlogEntryCount.relatedEntryCount>
@@ -1814,21 +1831,21 @@
 		<cfset var getRelatedP = "" />
 
 		<cfquery name="getRelatedP" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select
-				tblblogcategories.categoryname,
-				tblblogentries.id,
-				tblblogentries.title,
-				tblblogentries.posted
-			from
-				tblblogentries inner join
-					(tblblogcategories inner join tblblogentriescategories on tblblogcategories.categoryid = tblblogentriescategories.categoryidfk) on
-						tblblogentries.id = tblblogentriescategories.entryidfk
+			select 
+				#application.tableprefix#tblBlogCategories.categoryname, 
+				#application.tableprefix#tblBlogEntries.id, 
+				#application.tableprefix#tblBlogEntries.title, 
+				#application.tableprefix#tblBlogEntries.posted
+			from 
+				#application.tableprefix#tblBlogEntries inner join 
+					(#application.tableprefix#tblBlogCategories inner join #application.tableprefix#tblBlogEntriescategories on #application.tableprefix#tblBlogCategories.categoryid = #application.tableprefix#tblBlogEntriescategories.categoryidfk) on 
+						#application.tableprefix#tblBlogEntries.id = #application.tableprefix#tblBlogEntriescategories.entryidfk
 
-			where tblblogcategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			where #application.tableprefix#tblBlogCategories.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">						
 			order by
-				tblblogcategories.categoryname,
-				tblblogentries.posted,
-				tblblogentries.title
+				#application.tableprefix#tblBlogCategories.categoryname, 
+				#application.tableprefix#tblBlogEntries.posted,
+				#application.tableprefix#tblBlogEntries.title
 		</cfquery>
 
 		<cfreturn getRelatedP />
@@ -1849,7 +1866,7 @@
 
 		<cfquery name="getPeople" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select		email, token, verified
-		from		tblblogsubscribers
+		from		#application.tableprefix#tblBlogSubscribers
 		where		blog = <cfqueryparam value="#instance.name#" cfsqltype="cf_sql_varchar" maxlength="50">
 		<cfif		arguments.verifiedonly>
 		and			verified = 1
@@ -1878,18 +1895,18 @@
 
 		<!--- RBB 11/02/2005: Added website to query --->
 		<cfquery name="getC" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			select		tblblogcomments.id, tblblogcomments.name, tblblogcomments.email, tblblogcomments.website,
-						<cfif instance.blogDBTYPE is NOT "ORACLE">tblblogcomments.comment<cfelse>to_char(tblblogcomments.comments) as comments</cfif>, tblblogcomments.posted, tblblogcomments.subscribe, tblblogentries.title as entrytitle, tblblogcomments.entryidfk
-			from		tblblogcomments, tblblogentries
-			where		tblblogcomments.entryidfk = tblblogentries.id
+			select		#application.tableprefix#tblBlogComments.id, #application.tableprefix#tblBlogComments.name, #application.tableprefix#tblBlogComments.email, #application.tableprefix#tblBlogComments.website, 
+						<cfif instance.blogDBTYPE is NOT "ORACLE">#application.tableprefix#tblBlogComments.comment<cfelse>to_char(#application.tableprefix#tblBlogComments.comments) as comments</cfif>, #application.tableprefix#tblBlogComments.posted, #application.tableprefix#tblBlogComments.subscribe, #application.tableprefix#tblBlogEntries.title as entrytitle, #application.tableprefix#tblBlogComments.entryidfk
+			from		#application.tableprefix#tblBlogComments, #application.tableprefix#tblBlogEntries
+			where		#application.tableprefix#tblBlogComments.entryidfk = #application.tableprefix#tblBlogEntries.id
 			<cfif structKeyExists(arguments, "id")>
-			and			tblblogcomments.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and			#application.tableprefix#tblBlogComments.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			</cfif>
-			and			tblblogentries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			and			#application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 			<!--- added 12/5/2006 by Trent Richardson --->
-			and tblblogcomments.moderated = 0
-
-			order by	tblblogcomments.posted #arguments.sortdir#
+			and #application.tableprefix#tblBlogComments.moderated = 0 
+			
+			order by	#application.tableprefix#tblBlogComments.posted #arguments.sortdir#
 		</cfquery>
 
 		<!--- DS 8/22/06: if this is oracle, do a q of q to return the data with column named "comment" --->
@@ -1953,16 +1970,16 @@
 		<!--- MSACCESS fix provided by Andy Florino --->
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		<cfif instance.blogDBType is "MSACCESS">
-		select tblblogroles.id
-		from tblblogroles, tbluserroles, tblusers
-		where (tblblogroles.id = tbluserroles.roleidfk and tbluserroles.username = tblusers.username)
+		select #application.tableprefix#tblblogroles.id
+		from #application.tableprefix#tblblogroles, #application.tableprefix#tbluserroles, tblusers
+		where (#application.tableprefix#tblblogroles.id = #application.tableprefix#tbluserroles.roleidfk and #application.tableprefix#tbluserroles.username = tblusers.username)
 		and tblusers.username = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">
 		and tblusers.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		<cfelse>
-		select	tblblogroles.id
-		from	tblblogroles
-		left join tbluserroles on tbluserroles.roleidfk = tblblogroles.id
-		left join tblusers on tbluserroles.username = tblusers.username
+		select	#application.tableprefix#tblblogroles.id
+		from	#application.tableprefix#tblblogroles
+		left join #application.tableprefix#tbluserroles on #application.tableprefix#tbluserroles.roleidfk = #application.tableprefix#tblblogroles.id
+		left join tblusers on #application.tableprefix#tbluserroles.username = tblusers.username
 		where tblusers.username = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">
 		and tblusers.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
 		</cfif>
@@ -2003,7 +2020,7 @@
 		<cfif not structKeyExists(variables.roles, 'admin')>
 			<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	id
-			from	tblblogroles
+			from	#application.tableprefix#tblblogroles
 			where	role = <cfqueryparam cfsqltype="cf_sql_varchar" value="Admin" maxlength="50">
 			</cfquery>
 			<cfset variables.roles['admin'] = q.id>
@@ -2012,7 +2029,7 @@
 		<cfif not structKeyExists(variables.roles, arguments.role)>
 			<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	id
-			from	tblblogroles
+			from	#application.tableprefix#tblblogroles
 			where	role = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.role#" maxlength="50">
 			</cfquery>
 			<cfset variables.roles[arguments.role] = q.id>
@@ -2036,8 +2053,8 @@
 
 		<!--- delete comment based on kill --->
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogcomments
-			where killcomment = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.kid#" maxlength="35">
+			delete from #application.tableprefix#tblBlogComments
+			where killcomment = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.kid#" maxlength="35">		
 		</cfquery>
 
 	</cffunction>
@@ -2047,7 +2064,7 @@
 		<cfargument name="searchterm" type="string" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		insert into tblblogsearchstats(searchterm, searched, blog)
+		insert into #application.tableprefix#tblBlogSearchStats(searchterm, searched, blog)
 		values(
 			<cfqueryparam value="#arguments.searchterm#" cfsqltype="cf_sql_varchar" maxlength="255">,
 			<cfqueryparam value="#blogNow()#" cfsqltype="cf_sql_timestamp">,
@@ -2062,7 +2079,7 @@
 		<cfargument name="entryid" type="uuid" required="true">
 	
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		update	tblblogentries
+		update	#application.tableprefix#tblblogentries
 		set		views = views + 1
 		where	id = <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
@@ -2107,8 +2124,8 @@ To unsubscribe, please go to this URL:
 			no subscribers. I don't think this is an issue though.
 		--->
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		update tblblogentries
-		set		mailed =
+		update #application.tableprefix#tblBlogEntries
+		set		mailed = 
 				<cfif instance.blogDBType is not "MYSQL">
 					<cfqueryparam value="true" cfsqltype="CF_SQL_BIT">
 			   <cfelse>
@@ -2136,7 +2153,7 @@ To unsubscribe, please go to this URL:
 		
 		<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	categoryalias
-		from	tblblogcategories
+		from	#application.tableprefix#tblBlogCategories
 		where	categoryid = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.catid#" maxlength="35">
 		</cfquery>
 
@@ -2195,7 +2212,7 @@ To unsubscribe, please go to this URL:
 				<cfif not structKeyExists(variables.lCache, arguments.entryid)>
 					<cfquery name="q" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 					select	posted, alias
-					from	tblblogentries
+					from	#application.tableprefix#tblBlogEntries
 					where	id = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.entryid#" maxlength="35">
 					</cfquery>
 					<!---// cache the link //--->
@@ -2370,7 +2387,7 @@ To unsubscribe, please go to this URL:
 		<cfargument name="categoryid" type="uuid" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogentriescategories
+			delete from #application.tableprefix#tblBlogEntriescategories
 			where categoryidfk = <cfqueryparam value="#arguments.categoryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			and entryidfk = <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
@@ -2382,7 +2399,7 @@ To unsubscribe, please go to this URL:
 		<cfargument name="entryid" type="uuid" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from tblblogentriescategories
+			delete from #application.tableprefix#tblBlogEntriescategories
 			where	entryidfk = <cfqueryparam value="#arguments.entryid#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 	</cffunction>
@@ -2400,7 +2417,7 @@ To unsubscribe, please go to this URL:
 		<!--- First, lets see if this guy is already subscribed. --->
 		<cfquery name="getMe" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	email
-		from	tblblogsubscribers
+		from	#application.tableprefix#tblBlogSubscribers
 		where	email = <cfqueryparam value="#arguments.email#" cfsqltype="cf_sql_varchar" maxlength="50">
 		<cfif structKeyExists(arguments, "token")>
 		and		token = <cfqueryparam value="#arguments.token#" cfsqltype="cf_sql_varchar" maxlength="35">
@@ -2409,7 +2426,7 @@ To unsubscribe, please go to this URL:
 
 		<cfif getMe.recordCount is 1>
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete	from tblblogsubscribers
+			delete	from #application.tableprefix#tblBlogSubscribers
 			where	email = <cfqueryparam value="#arguments.email#" cfsqltype="cf_sql_varchar" maxlength="50">
 			<cfif structKeyExists(arguments, "token")>
 			and		token = <cfqueryparam value="#arguments.token#" cfsqltype="cf_sql_varchar" maxlength="35">
@@ -2428,7 +2445,7 @@ To unsubscribe, please go to this URL:
 				hint="Removes all subscribers who are not verified.">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		delete	from tblblogsubscribers
+		delete	from #application.tableprefix#tblBlogSubscribers
 		where	blog = <cfqueryparam value="#instance.name#" cfsqltype="cf_sql_varchar" maxlength="50">
 		and		verified = 0
 		</cfquery>
@@ -2578,7 +2595,7 @@ To unsubscribe, please go to this URL:
 
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		update tblblogcomments
+		update #application.tableprefix#tblBlogComments
 		set name = <cfqueryparam value="#arguments.name#" maxlength="50">,
 		email = <cfqueryparam value="#arguments.email#" maxlength="50">,
 		website = <cfqueryparam value="#arguments.website#" maxlength="255">,
@@ -2640,7 +2657,7 @@ To unsubscribe, please go to this URL:
 		</cfif>
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			update tblblogentries
+			update #application.tableprefix#tblBlogEntries
 			set		title = <cfqueryparam value="#arguments.title#" cfsqltype="CF_SQL_CHAR" maxlength="100">,
 					<cfif instance.blogDBType is not "ORACLE">
 					body = <cfqueryparam value="#arguments.body#" cfsqltype="CF_SQL_LONGVARCHAR">
@@ -2739,16 +2756,16 @@ To unsubscribe, please go to this URL:
 		<cfset var ppost = "" />
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			delete from
-				tblblogentriesrelated
-			where
+			delete from 
+				#application.tableprefix#tblBlogEntriesrelated 
+			where 
 				entryid = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 		</cfquery>
 
 		<cfloop list="#arguments.relatedpposts#" index="ppost">
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 				insert into
-					tblblogentriesrelated(
+					#application.tableprefix#tblBlogEntriesrelated(
 						entryid,
 						relatedid
 					) values (
@@ -2802,7 +2819,7 @@ To unsubscribe, please go to this URL:
 		<cfargument name="id" type="string" required="true">
 
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			update tblblogcomments set moderated=1 where id=<cfqueryparam value="#arguments.id#" cfsqltype="cf_sql_varchar">
+			update #application.tableprefix#tblblogcomments set moderated=1 where id=<cfqueryparam value="#arguments.id#" cfsqltype="cf_sql_varchar">
 		</cfquery>
 
 	</cffunction>
@@ -2815,14 +2832,14 @@ To unsubscribe, please go to this URL:
 		<cfset var r = "" />
 		<!--- first, nuke old roles --->
 		<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-		delete from tbluserroles
+		delete from #application.tableprefix#tbluserroles
 		where username = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">
 		and blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#instance.name#" maxlength="50">
 		</cfquery>
 
 		<cfloop index="r" list="#arguments.roles#">
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			insert into tbluserroles(username, roleidfk, blog)
+			insert into #application.tableprefix#tbluserroles(username, roleidfk, blog)
 			values(
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.username#" maxlength="50">,
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#r#" maxlength="35">,
@@ -2843,7 +2860,7 @@ To unsubscribe, please go to this URL:
 		<!--- First ensure that the commentID equals the email --->
 		<cfquery name="verifySubscribe" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 			select	entryidfk
-			from	tblblogcomments
+			from	#application.tableprefix#tblBlogComments
 			where	id = <cfqueryparam value="#arguments.commentID#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 			and		email = <cfqueryparam value="#arguments.email#" cfsqltype="CF_SQL_VARCHAR" maxlength="100">
 		</cfquery>
@@ -2852,7 +2869,7 @@ To unsubscribe, please go to this URL:
 		<cfif verifySubscribe.recordCount>
 
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-				update	tblblogcomments
+				update	#application.tableprefix#tblBlogComments
 				set		subscribe = 0
 				where	entryidfk = <cfqueryparam value="#verifySubscribe.entryidfk#"
 									cfsqltype="CF_SQL_VARCHAR" maxlength="35">
@@ -2875,7 +2892,7 @@ To unsubscribe, please go to this URL:
 
 		<cfquery name="checkit" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
 		select	password, salt
-		from	tblusers
+		from	#application.tableprefix#tblusers
 		where	username = <cfqueryparam value="#getAuthUser()#" cfsqltype="cf_sql_varchar" maxlength="50">
 		<!---
 		and		password = <cfqueryparam value="#arguments.oldpassword#" cfsqltype="cf_sql_varchar" maxlength="255">
@@ -2887,7 +2904,7 @@ To unsubscribe, please go to this URL:
 			<!--- generate a new salt --->
 			
 			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
-			update	tblusers
+			update	#application.tableprefix#tblusers
 			set		password = <cfqueryparam value="#hash(salt & arguments.newpassword, instance.hashalgorithm)#" cfsqltype="cf_sql_varchar" maxlength="256">,
 					salt = <cfqueryparam value="#salt#" cfsqltype="cf_sql_varchar" maxlength="256">
 			where	username = <cfqueryparam value="#getAuthUser()#" cfsqltype="cf_sql_varchar" maxlength="50">
@@ -2908,8 +2925,5 @@ To unsubscribe, please go to this URL:
 		
 		<cfreturn generateSecretKey(instance.saltAlgorithm, instance.saltKeySize)>
 	</cffunction>
-
-	
-	
 
 </cfcomponent>

--- a/client/org/camden/blog/downloadtracker.cfc
+++ b/client/org/camden/blog/downloadtracker.cfc
@@ -1,0 +1,367 @@
+<cfcomponent>
+
+	<cffunction name="init" access="public" returnType="downloadtracker" output="false">
+		<cfreturn this>
+	</cffunction>
+
+<!---
+	<cffunction name="generateRSS" access="remote" returnType="string" output="false"
+				hint="Attempts to generate RSS 1.0">
+		<cfargument name="mode" type="string" required="false" default="short" hint="If mode=short, show EXCERPT chars of entries. Otherwise, show all.">
+		<cfargument name="excerpt" type="numeric" required="false" default="250" hint="If mode=short, this how many chars to show.">
+		<cfargument name="params" type="struct" required="false" default="#structNew()#" hint="Passed to getEntries. Note, maxEntries can't be bigger than 15.">
+		<cfargument name="version" type="numeric" required="false" default="2" hint="RSS verison, Options are 1 or 2">		
+		<cfargument name="additionalTitle" type="string" required="false" default="" hint="Adds a title to the end of your blog title. Used mainly by the cat view.">
+		
+		<cfset var articles = "">
+		<cfset var z = getTimeZoneInfo()>
+		<cfset var header = "">
+		<cfset var channel = "">
+		<cfset var items = "">
+		<cfset var dateStr = "">
+		<cfset var rssStr = "">
+		<cfset var utcPrefix = "">
+		<cfset var rootURL = "">
+		<cfset var cat = "">
+		<cfset var lastid = "">
+		<cfset var catid = "">
+		<cfset var catlist = "">
+		
+		<!--- Right now, we force this in. Useful to limit throughput of RSS feed. I may remove this later. --->
+		<cfif (structKeyExists(arguments.params,"maxEntries") and arguments.params.maxEntries gt 15) or not structKeyExists(arguments.params,"maxEntries")>
+			<cfset arguments.params.maxEntries = 15>
+		</cfif>
+		
+		<cfset articleData = getEntries(params)>
+	    <cfset articles = articleData.entries>
+
+		<cfif not find("-", z.utcHourOffset)>
+			<cfset utcPrefix = " -">
+		<cfelse>
+			<cfset z.utcHourOffset = right(z.utcHourOffset, len(z.utcHourOffset) -1 )>
+			<cfset utcPrefix = " +">
+		</cfif>
+		
+		
+		<cfif arguments.version is 1>
+	
+			<cfsavecontent variable="header">
+			<cfoutput>
+			<?xml version="1.0" encoding="utf-8"?>
+			
+			<rdf:RDF 
+				xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns##"
+				xmlns:dc="http://purl.org/dc/elements/1.1/"
+				xmlns="http://purl.org/rss/1.0/"
+			>
+			</cfoutput>
+			</cfsavecontent>
+	
+			<cfsavecontent variable="channel">
+			<cfoutput>
+			<channel rdf:about="#xmlFormat(instance.blogURL)#">
+			<title>#xmlFormat(instance.blogTitle)##xmlFormat(arguments.additionalTitle)#</title>
+			<description>#xmlFormat(instance.blogDescription)#</description>
+			<link>#xmlFormat(instance.blogURL)#</link>
+		
+			<items>
+				<rdf:Seq>
+					<cfloop query="articles">
+					<rdf:li rdf:resource="#xmlFormat(makeLink(id))#" />
+					</cfloop>
+				</rdf:Seq>
+			</items>
+			
+			</channel>
+			</cfoutput>
+			</cfsavecontent>
+	
+			<cfsavecontent variable="items">
+			<cfloop query="articles">
+			<cfset dateStr = dateFormat(posted,"yyyy-mm-dd")>
+			<cfset dateStr = dateStr & "T" & timeFormat(posted,"HH:mm:ss") & utcPrefix & numberFormat(z.utcHourOffset,"00") & ":00">
+			<cfoutput>
+		  	<item rdf:about="#xmlFormat(makeLink(id))#">
+			<title>#xmlFormat(title)#</title>
+			<description><cfif arguments.mode is "short" and len(REReplaceNoCase(body,"<[^>]*>","","ALL")) gte arguments.excerpt>#xmlFormat(left(REReplaceNoCase(body,"<[^>]*>","","ALL"),arguments.excerpt))#...<cfelse>#xmlFormat(body)#</cfif><cfif len(morebody)> [More]</cfif></description>
+			<link>#xmlFormat(makeLink(id))#</link>
+			<dc:date>#dateStr#</dc:date>
+			<cfloop item="catid" collection="#categories#">
+				<cfset catlist = listAppend(catlist, xmlFormat(categories[currentRow][catid]))>
+			</cfloop>
+			<dc:subject>#xmlFormat(catlist)#</dc:subject>
+
+			</item>
+			</cfoutput>
+		 	</cfloop>
+			</cfsavecontent>
+	
+			<cfset rssStr = trim(header & channel & items & "</rdf:RDF>")>
+	
+		<cfelseif arguments.version eq "2">
+		
+			<cfset rootURL = reReplace(instance.blogURL, "(.*)/index.cfm", "\1")>
+
+			<cfsavecontent variable="header">
+			<cfoutput>
+			<?xml version="1.0" encoding="utf-8"?>
+			
+			<rss version="2.0" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns##" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/">
+
+			<channel>
+			<title>#xmlFormat(instance.blogTitle)##xmlFormat(arguments.additionalTitle)#</title>
+			<link>#xmlFormat(instance.blogURL)#</link>
+			<description>#xmlFormat(instance.blogDescription)#</description>
+			<language>#replace(lcase(instance.locale),'_','-','one')#</language>
+			<pubDate>#dateFormat(blogNow(),"ddd, dd mmm yyyy") & " " & timeFormat(blogNow(),"HH:mm:ss") & utcPrefix & numberFormat(z.utcHourOffset,"00") & "00"#</pubDate>
+			<lastBuildDate>{LAST_BUILD_DATE}</lastBuildDate>
+			<generator>BlogCFC</generator>
+			<docs>http://blogs.law.harvard.edu/tech/rss</docs>
+			<!---- JH DotComIt added code to turn e-mails into unitext, removed xmlformat ---->
+			<managingEditor>#(variables.utils.EmailAntiSpam(instance.owneremail))#</managingEditor>
+			<webMaster>#(variables.utils.EmailAntiSpam(instance.owneremail))#</webMaster>
+			<media:copyright>Copyright 2008, DotComIt LLC</media:copyright>
+			<media:thumbnail url="#xmlFormat(instance.itunesImage)#" />
+			<media:keywords>#xmlFormat(instance.itunesKeywords)#</media:keywords>
+			<media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Software How-To</media:category>
+			<media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Tech News</media:category>
+
+			<itunes:subtitle>#xmlFormat(instance.itunesSubtitle)#</itunes:subtitle>
+			<itunes:summary>#xmlFormat(instance.itunesSummary)#</itunes:summary>
+			<itunes:category text="Technology">
+				<itunes:category text="Software How-To" />
+			</itunes:category>
+			<itunes:category text="Technology">
+				<itunes:category text="Podcasting" />
+			</itunes:category>
+			<itunes:category text="Technology">
+				<itunes:category text="Tech News" />
+			</itunes:category>
+			<itunes:keywords>#xmlFormat(instance.itunesKeywords)#</itunes:keywords>
+			<itunes:author>#xmlFormat(instance.itunesAuthor)#</itunes:author>
+			<itunes:owner>
+				<itunes:email>#xmlFormat(instance.owneremail)#</itunes:email>
+				<itunes:name>#xmlFormat(instance.itunesAuthor)#</itunes:name>
+			</itunes:owner>
+			<itunes:image href="#xmlFormat(instance.itunesImage)#" />
+			<image>
+				<url>#xmlFormat(instance.itunesImage)#</url>
+				<title>#xmlFormat(instance.blogTitle)#</title>
+				<link>#xmlFormat(instance.blogURL)#</link>
+			</image>
+			<itunes:explicit>#xmlFormat(instance.itunesExplicit)#</itunes:explicit>
+			</cfoutput>
+			</cfsavecontent>
+		
+			<cfsavecontent variable="items">
+			<cfloop query="articles">
+			<cfset dateStr = dateFormat(posted,"ddd, dd mmm yyyy") & " " & timeFormat(posted,"HH:mm:ss") & utcPrefix & numberFormat(z.utcHourOffset,"00") & "00">
+			<cfoutput>
+			<item>
+				<title>#xmlFormat(title)#</title>
+				<link>#xmlFormat(makeLink(id))#</link>
+				<description>
+				<!--- Regex operation removes HTML code from blog body output --->
+				<cfif arguments.mode is "short" and len(REReplaceNoCase(body,"<[^>]*>","","ALL")) gte arguments.excerpt>
+				#xmlFormat(left(REReplace(body,"<[^>]*>","","All"),arguments.excerpt))#...
+				<cfelse>#xmlFormat(body)#</cfif>
+				<cfif len(morebody)> [More]</cfif>
+				</description>
+				<cfset lastid = listLast(structKeyList(categories))>		
+				<cfloop item="catid" collection="#categories#">
+				<category>#xmlFormat(categories[currentRow][catid])#</category>				
+				</cfloop>
+				<pubDate>#dateStr#</pubDate>
+				<guid>#xmlFormat(makeLink(id))#</guid>
+				<author>#xmlFormat(instance.owneremail)# (#xmlFormat(instance.itunesAuthor)#)</author>
+				
+				<cfif len(enclosure)>
+				<enclosure url="#xmlFormat("#rooturl#/download.cfm/id/#id#/#getFileFromPath(enclosure)#")#" length="#filesize#" type="#mimetype#"/>
+				<cfif mimetype IS "audio/mpeg">
+				<itunes:author>#xmlFormat(instance.itunesAuthor)#</itunes:author>
+				<itunes:explicit>#xmlFormat(instance.itunesExplicit)#</itunes:explicit>
+				<itunes:duration>#xmlFormat(duration)#</itunes:duration>
+				<itunes:keywords>#xmlFormat(keywords)#</itunes:keywords>
+				<itunes:subtitle>#xmlFormat(subtitle)#</itunes:subtitle>
+				<itunes:summary>#xmlFormat(summary)#</itunes:summary>
+				<itunes:image href="#xmlFormat(instance.itunesImage)#" />
+				</cfif>
+				</cfif>
+			</item>
+			</cfoutput>
+		 	</cfloop>
+			</cfsavecontent>
+		
+			<cfset header = replace(header,'{LAST_BUILD_DATE}','#dateFormat(articles.posted[1],"ddd, dd mmm yyyy") & " " & timeFormat(articles.posted[1],"HH:mm:ss") & utcPrefix & numberFormat(z.utcHourOffset,"00") & "00"#','one')>
+			<cfset rssStr = trim(header & items & "</channel></rss>")>
+		
+		</cfif>
+							
+		<cfreturn rssStr>
+		
+	</cffunction>
+--->
+
+<!---
+
+	<cffunction name="getEntry" access="remote" returnType="struct" output="false"
+				hint="Returns one particular entry.">
+		<cfargument name="id" type="uuid" required="true">
+		<cfargument name="dontlog" type="boolean" required="false" default="false">
+		<cfargument name="IsAvailable" type="boolean" required="false" default="true">
+		<cfset var getIt = "">
+		<cfset var s = structNew()>
+		<cfset var col = "">
+		<cfset var getCategories = "">
+		
+		<cfif not entryExists(arguments.id,arguments.IsAvailable)>
+			<cfset variables.utils.throw("#arguments.id# does not exist.")>
+		</cfif>
+	
+		<cfquery name="getIt" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
+			select		#application.tableprefix#tblBlogEntries.id, #application.tableprefix#tblBlogEntries.title, 
+						<!--- Handle offset --->
+						<cfif instance.blogDBType is "MSACCESS">
+						dateAdd('h', #instance.offset#, #application.tableprefix#tblBlogEntries.posted) as posted, 
+						<cfelseif instance.blogDBType is "MSSQL">
+						dateAdd(hh, #instance.offset#, #application.tableprefix#tblBlogEntries.posted) as posted, 
+						<cfelseif instance.blogDBType is "ORACLE">
+						#application.tableprefix#tblBlogEntries.posted + (#instance.offset#/24) as posted,
+						<cfelse>
+						date_add(posted, interval #instance.offset# hour) as posted, 
+						</cfif>
+						#application.tableprefix#tblBlogEntries.body, 
+						#application.tableprefix#tblBlogEntries.morebody, #application.tableprefix#tblBlogEntries.alias, #application.tableprefix#tblUsers.name, #application.tableprefix#tblBlogEntries.allowcomments,
+						#application.tableprefix#tblBlogEntries.enclosure, #application.tableprefix#tblBlogEntries.filesize, #application.tableprefix#tblBlogEntries.mimetype, #application.tableprefix#tblBlogEntries.released, #application.tableprefix#tblBlogEntries.mailed,
+						#application.tableprefix#tblBlogEntries.summary, #application.tableprefix#tblBlogEntries.keywords, #application.tableprefix#tblBlogEntries.subtitle, #application.tableprefix#tblBlogEntries.duration
+			from		#application.tableprefix#tblBlogEntries, #application.tableprefix#tblUsers
+			where		#application.tableprefix#tblBlogEntries.id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and			#application.tableprefix#tblBlogEntries.blog = <cfqueryparam value="#instance.name#" cfsqltype="CF_SQL_VARCHAR" maxlength="50">
+			and			#application.tableprefix#tblBlogEntries.username = #application.tableprefix#tblUsers.username
+		</cfquery>
+
+		<cfquery name="getCategories" datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
+			select	categoryid,categoryname
+			from	#application.tableprefix#tblBlogCategories, #application.tableprefix#tblblogentriescategories
+			where	#application.tableprefix#tblblogentriescategories.entryidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			and		#application.tableprefix#tblblogentriescategories.categoryidfk = #application.tableprefix#tblBlogCategories.categoryid
+		</cfquery>
+				
+		<cfloop index="col" list="#getIt.columnList#">
+			<cfset s[col] = getIt[col][1]>
+		</cfloop>
+
+		<cfset s.categories = structNew()>
+		<cfloop query="getCategories">
+			<cfset s.categories[categoryid] = categoryname>
+		</cfloop>
+		
+		<!--- Handle view --->
+		<cfif not arguments.dontlog>
+			<cfquery datasource="#instance.dsn#" username="#instance.username#" password="#instance.password#">
+			update	#application.tableprefix#tblBlogEntries
+			set		views = views + 1
+			where	id = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+			</cfquery>
+		</cfif>
+				
+		<cfreturn s>
+		
+	</cffunction>--->
+
+
+
+	<!--- added by Jeffry Houser --->
+	<cffunction name="logEnclosureDownload" access="public" returnType="void" output="false"
+				hint="I save download, or view, data based on an enclosure">
+		<cfargument name="id" type="string" required="true" hint="entry.id">
+		<cfargument name="enclosure" type="string" required="true" hint="entry.enclosure">
+		<cfargument name="dir" type="string" required="true" hint="url.dir">
+		<cfargument name="online" type="Boolean" required="false" default="0" hint="url.online">
+
+		
+		<cfquery datasource="#application.blog.getProperty("dsn")#" username="#application.blog.getProperty("username")#" password="#application.blog.getProperty("password")#">
+			insert into #application.tableprefix#tblblogenclosuredownloads(id,entryid,ipaddress,http_referrer, HTTP_USER_AGENT, downloaddate, downloadtime, enclosure,Path, online )
+			values(
+				<cfqueryparam value="#createuuid()#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">,
+				<cfif arguments.id is 0>
+					null,
+				<cfelse>
+					<cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35" >,
+				</cfif> <!--- null="#not(YesNoFormat(entry.id))#" --->
+				<cfqueryparam value="#cgi.REMOTE_ADDR#" cfsqltype="CF_SQL_VARCHAR" maxlength="15">,
+				<cfqueryparam value="#cgi.HTTP_REFERER#" cfsqltype="CF_SQL_VARCHAR" maxlength="255">,
+				<cfqueryparam value="#cgi.HTTP_USER_AGENT#" cfsqltype="CF_SQL_VARCHAR" maxlength="255">,
+				#createodbcdate(now())#, #createodbctime(now())#, 
+				<cfqueryparam value="#getFileFromPath(arguments.enclosure)#" cfsqltype="CF_SQL_VARCHAR" maxlength="255">,
+				<cfqueryparam value="#arguments.dir#" cfsqltype="CF_SQL_VARCHAR" maxlength="255">,
+				<cfqueryparam value="#arguments.online#" cfsqltype="cf_sql_bit">		
+				 )
+		</cfquery>
+			
+
+	</cffunction>
+
+	<!--- added by Jeffry Houser --->
+	<cffunction name="generateDownloadReport" access="public" returnType="query" output="false"
+				hint="I figure out how many episode downloads have happened in the given time frame">
+		<cfargument name="StartDate" type="date" required="false" default="#now()#">
+		<cfargument name="EndDate" type="date" required="false" default="#now()#">
+		
+		<cfset var generateReport = "">
+		
+		<!--- Query to differentiate between on-line and not online stats 
+SELECT     TOP 100 PERCENT dbo.#application.tableprefix#tblBlogEntries.id, dbo.#application.tableprefix#tblBlogEntries.title, COUNT(dbo.#application.tableprefix#tblblogenclosuredownloads.entryid) AS TotalDownloads
+FROM         dbo.#application.tableprefix#tblBlogEntries INNER JOIN
+                      dbo.#application.tableprefix#tblblogenclosuredownloads ON dbo.#application.tableprefix#tblBlogEntries.id = dbo.#application.tableprefix#tblblogenclosuredownloads.entryid
+WHERE     (dbo.#application.tableprefix#tblblogenclosuredownloads.Online = 0) AND (dbo.#application.tableprefix#tblblogenclosuredownloads.downloaddate BETWEEN CONVERT(DATETIME, '2008-09-01', 102) 
+                      AND CONVERT(DATETIME, '2008-11-30', 102))
+GROUP BY dbo.#application.tableprefix#tblBlogEntries.id, dbo.#application.tableprefix#tblBlogEntries.title
+ORDER BY dbo.#application.tableprefix#tblBlogEntries.title		
+		
+		---->
+		
+		<cfquery name="generateReport" datasource="#application.blog.getProperty("dsn")#" username="#application.blog.getProperty("username")#" password="#application.blog.getProperty("password")#">
+			SELECT     TOP 100 PERCENT dbo.#application.tableprefix#tblBlogEntries.id, dbo.#application.tableprefix#tblBlogEntries.posted, dbo.#application.tableprefix#tblBlogEntries.title, COUNT(dbo.#application.tableprefix#tblblogenclosuredownloads.entryid) AS TotalDownloads
+			FROM         dbo.#application.tableprefix#tblBlogEntries INNER JOIN
+			                      dbo.#application.tableprefix#tblblogenclosuredownloads ON dbo.#application.tableprefix#tblBlogEntries.id = dbo.#application.tableprefix#tblblogenclosuredownloads.entryid
+			where dbo.#application.tableprefix#tblblogenclosuredownloads.downloaddate between #createodbcdate(startdate)#  and #createodbcdate(enddate)# 
+			GROUP BY dbo.#application.tableprefix#tblBlogEntries.id, dbo.#application.tableprefix#tblBlogEntries.posted, dbo.#application.tableprefix#tblBlogEntries.title
+			ORDER BY dbo.#application.tableprefix#tblBlogEntries.posted, dbo.#application.tableprefix#tblBlogEntries.title
+		</cfquery>
+		
+		<Cfreturn generateReport>
+
+	</cffunction>
+
+	<cffunction name="generateImpressionReport" access="public" returnType="query" output="false"
+				hint="I figure out how many impressions different media has had">
+		<cfargument name="StartDate" type="date" required="false" default="#now()#">
+		<cfargument name="EndDate" type="date" required="false" default="#now()#">
+
+		<cfset var generateReport = "">
+		
+		<cfquery name="generateReport" datasource="#application.blog.getProperty("dsn")#" username="#application.blog.getProperty("username")#" password="#application.blog.getProperty("password")#">
+<!--- 
+	This is causing problems; not properly filtering out date data
+
+			select distinct ad_MediaViews.MediaText, ad_MediaViews.totalViews, ad_MediaViews.Description
+			from ad_MediaViews  
+				join ad_MediaLog on (Ad_MediaViews.MediaID = ad_MediaLog.mediaID and 
+										ad_MediaLog.DateDisplayed between #createodbcdate(startdate)#  and #createodbcdate(enddate)#)
+ --->
+			select count(ad_MediaLog.MediaLogID) as totalviews, ad_Media.MediaText, ad_Media.Description
+			from ad_MediaLog, ad_Media
+			where ( ad_MediaLog.DateDisplayed between #createodbcdate(startdate)#  and #createodbcdate(enddate)# ) and 
+					ad_media.mediaID = ad_MediaLog.MediaID
+			group by ad_Media.MediaText, ad_Media.Description
+
+		</cfquery>
+
+		
+		
+		<Cfreturn generateReport>
+
+	</cffunction>
+
+</cfcomponent>

--- a/client/org/camden/blog/page.cfc
+++ b/client/org/camden/blog/page.cfc
@@ -23,14 +23,14 @@
 	<cfargument name="id" type="uuid" required="true">
 
 	<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-	delete from tblblogpages
+	delete from #application.tableprefix#tblblogpages
 	where	id = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">
 	and		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	</cfquery>
 
 	<!--- remove all cats --->
 	<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-	delete from tblblogpagescategories
+	delete from #application.tableprefix#tblblogpagescategories
 	where pageidfk = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">
 	</cfquery>
 
@@ -44,9 +44,9 @@
 
 
 	select	tblblogcategories.categoryID, tblblogcategories.categoryname
-	from	tblblogcategories, tblblogpagescategories
-	where	tblblogcategories.categoryID = tblblogpagescategories.categoryidfk
-	and		tblblogpagescategories.pageidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
+	from	tblblogcategories, #application.tableprefix#tblblogpagescategories
+	where	tblblogcategories.categoryID = #application.tableprefix#tblblogpagescategories.categoryidfk
+	and		#application.tableprefix#tblblogpagescategories.pageidfk = <cfqueryparam value="#arguments.id#" cfsqltype="CF_SQL_VARCHAR" maxlength="35">
 	</cfquery>
 	<cfreturn q>	
 </cffunction>
@@ -58,7 +58,7 @@
 
 	<cfquery name="q" datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
 	select		id, blog, title, alias, body, showlayout
-	from		tblblogpages
+	from		#application.tableprefix#tblblogpages
 	where		id = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">
 	and			blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	</cfquery>
@@ -83,7 +83,7 @@
 
 	<cfquery name="q" datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
 	select		id, blog, title, alias, body, showlayout
-	from		tblblogpages
+	from		#application.tableprefix#tblblogpages
 	where		alias = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.alias#" maxlength="100">
 	and			blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	</cfquery>
@@ -105,7 +105,7 @@
 
 	<cfquery name="q" datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
 	select		id, blog, title, alias, body, showlayout
-	from		tblblogpages
+	from		#application.tableprefix#tblblogpages
 	where		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	order by 	title asc
 	</cfquery>
@@ -127,7 +127,7 @@
 		<cfset arguments.id = createUUID()>
 
 		<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-		insert into tblblogpages(id, title, alias, body, blog, showlayout)
+		insert into #application.tableprefix#tblblogpages(id, title, alias, body, blog, showlayout)
 		values(
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">,
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.title#" maxlength="255">,
@@ -141,7 +141,7 @@
 	<cfelse>
 
 		<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-		update tblblogpages
+		update #application.tableprefix#tblblogpages
 		set
 				title = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.title#" maxlength="255">,
 				alias = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.alias#" maxlength="100">,
@@ -154,13 +154,13 @@
 
 	<!--- remove all cats --->
 	<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-	delete from tblblogpagescategories
+	delete from #application.tableprefix#tblblogpagescategories
 	where pageidfk = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">
 	</cfquery>
 	
 	<cfloop index="c" list="#arguments.categories#">
 		<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-		insert into tblblogpagescategories(pageidfk,categoryidfk)
+		insert into #application.tableprefix#tblblogpagescategories(pageidfk,categoryidfk)
 		values(
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">,
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#c#" maxlength="35">

--- a/client/org/camden/blog/textblock.cfc
+++ b/client/org/camden/blog/textblock.cfc
@@ -31,7 +31,7 @@
 	<cfargument name="id" type="uuid" required="true">
 	
 	<cfquery datasource="#variables.dsn#" username="#variables.username#" password="#variables.password#">
-	delete from tblblogtextblocks
+	delete from #application.tableprefix#tblblogtextblocks
 	where	id = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">
 	and		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	</cfquery>
@@ -45,7 +45,7 @@
 	
 	<cfquery name="q" datasource="#variables.dsn#"  username="#variables.username#" password="#variables.password#">
 	select		id, label, body
-	from		tblblogtextblocks
+	from		#application.tableprefix#tblblogtextblocks
 	where		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	<cfif structKeyExists(arguments, "label")>
 	and		label = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.label#" maxlength="255">
@@ -70,7 +70,7 @@
 	
 	<cfquery name="q" datasource="#variables.dsn#"  username="#variables.username#" password="#variables.password#">
 	select		id, label, body
-	from		tblblogtextblocks
+	from		#application.tableprefix#tblblogtextblocks
 	where		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">
 	and		  	label = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.label#" maxlength="255">
 	</cfquery>
@@ -84,7 +84,7 @@
 	
 	<cfquery name="q" datasource="#variables.dsn#"  username="#variables.username#" password="#variables.password#">
 	select		id, label, body
-	from		tblblogtextblocks
+	from		#application.tableprefix#tblblogtextblocks
 	where		blog = <cfqueryparam cfsqltype="cf_sql_varchar" value="#variables.blog#" maxlength="50">	
 	order by 	label asc
 	</cfquery>
@@ -101,7 +101,7 @@
 		<cfset arguments.id = createUUID()>
 
 		<cfquery datasource="#variables.dsn#"  username="#variables.username#" password="#variables.password#">
-		insert into tblblogtextblocks(id, label, body, blog)
+		insert into #application.tableprefix#tblblogtextblocks(id, label, body, blog)
 		values(
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.id#" maxlength="35">,
 			<cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.label#" maxlength="255">,
@@ -113,7 +113,7 @@
 	<cfelse>
 	
 		<cfquery datasource="#variables.dsn#"  username="#variables.username#" password="#variables.password#">
-		update tblblogtextblocks
+		update #application.tableprefix#tblblogtextblocks
 		set
 				label = <cfqueryparam cfsqltype="cf_sql_varchar" value="#arguments.label#" maxlength="255">,
 				body = <cfqueryparam cfsqltype="cf_sql_longvarchar" value="#arguments.body#">

--- a/client/org/camden/blog/utils.cfc
+++ b/client/org/camden/blog/utils.cfc
@@ -92,4 +92,221 @@
 		
 		<cfreturn reReplace(arguments.url, "\/{2,}", "/", "all")>
 	</cffunction>
+
+	<cfscript>
+/**
+ * When given an email address this function will return the address in a format safe from email harvesters.
+ * Minor edit by Rob Brooks-Bilson (rbils@amkor.com)
+ * Update now converts all characters in the email address to unicode, not just the @ symbol. (by author)
+ *
+ * @param EmailAddress 	 Email address you want to make safe. (Required)
+ * @param Mailto 	 Boolean (Yes/No). Indicates whether to return formatted email address as a mailto link.  Default is No. (Optional)
+ * @return Returns a string
+ * @author Seth Duffey (rbils@amkor.comsduffey@ci.davis.ca.us)
+ * @version 2, May 2, 2002
+ */
+		function EmailAntiSpam(EmailAddress) {
+			var i = 1;
+			var antiSpam = "";
+			for (i=1; i LTE len(EmailAddress); i=i+1) {
+				antiSpam = antiSpam & "&##" & asc(mid(EmailAddress,i,1)) & ";";
+			}
+			if ((ArrayLen(Arguments) eq 2) AND (Arguments[2] is "Yes")) return "<a href=" & "mailto:" & antiSpam & ">" & antiSpam & "</a>";
+			else return antiSpam;
+		}
+	</cfscript>
+
+	<cffunction name="toHTML" returntype="string">
+		<cfargument name="source" type="string" required="true" />
+<!---- Change greater than and less than back into non-HTML escaped characters --->
+		<cfset var result = replacenocase(replacenocase(source,'&lt;','<','all'),'&gt;','>','all')>
+<!---- Change %22 back into quotes --->
+		<cfset result = replacenocase(result,"&quot;","""","all")>
+		<cfreturn result>
+	</cffunction>
+
+	<cfscript>
+		function titleCase(str) {
+			return uCase(left(str,1)) & right(str,len(str)-1);
+		}
+
+/**
+* Tests passed value to see if it is a valid e-mail address (supports subdomain nesting and new top-level domains).
+* Update by David Kearns to support '
+* SBrown@xacting.com pointing out regex still wasn't accepting ' correctly.
+* More TLDs
+* Version 4 by P Farrel, supports limits on u/h
+* Added mobi
+* v6 more tlds
+*
+* @param str      The string to check. (Required)
+* @return Returns a boolean.
+* @author Jeff Guillaume (SBrown@xacting.comjeff@kazoomis.com)
+* @version 6, July 29, 2008
+* Note this is different from CFLib as it has the "allow +" support
+*/
+		function isEmail(str) {
+			return (REFindNoCase("^['_a-z0-9-]+(\.['_a-z0-9-]+)*(\+['_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*\.(([a-z]{2,3})|(aero|asia|biz|cat|coop|info|museum|name|jobs|post|pro|tel|travel|mobi))$",arguments.str) AND len(listGetAt(arguments.str, 1, "@")) LTE 64 AND
+				len(listGetAt(arguments.str, 2, "@")) LTE 255) IS 1;
+		}
+
+		function isLoggedIn() {
+			return structKeyExists(session,"loggedin");
+		}
+
+/**
+ * An &quot;enhanced&quot; version of ParagraphFormat.
+ * Added replacement of tab with nonbreaking space char, idea by Mark R Andrachek.
+ * Rewrite and multiOS support by Nathan Dintenfas.
+ *
+ * @param string 	 The string to format. (Required)
+ * @return Returns a string.
+ * @author Ben Forta (ben@forta.com)
+ * @version 3, June 26, 2002
+ */
+		function ParagraphFormat2(str) {
+//first make Windows style into Unix style
+			str = replace(str,chr(13)&chr(10),chr(10),"ALL");
+//now make Macintosh style into Unix style
+			str = replace(str,chr(13),chr(10),"ALL");
+//now fix tabs
+			str = replace(str,chr(9),"&nbsp;&nbsp;&nbsp;","ALL");
+//now return the text formatted in HTML
+			return replace(str,chr(10),"<br />","ALL");
+		}
+
+/**
+ * A quick way to test if a string is a URL
+ *
+ * @param stringToCheck 	 The string to check.
+ * @return Returns a boolean.
+ * @author Nathan Dintenfass (nathan@changemedia.com)
+ * @version 1, November 22, 2001
+ */
+		function isURL(stringToCheck){
+			return REFindNoCase("^(((https?:|ftp:|gopher:)\/\/))[-[:alnum:]\?%,\.\/&##!@:=\+~_]+[A-Za-z0-9\/]$",stringToCheck) NEQ 0;
+		}
+
+/**
+ * Converts a byte value into kb or mb if over 1,204 bytes.
+ *
+ * @param bytes 	 The number of bytes. (Required)
+ * @return Returns a string.
+ * @author John Bartlett (jbartlett@strangejourney.net)
+ * @version 1, July 31, 2005
+ */
+		function KBytes(bytes) {
+			var b=0;
+
+			if(arguments.bytes lt 1024) return trim(numberFormat(arguments.bytes,"9,999")) & " bytes";
+
+			b=arguments.bytes / 1024;
+
+			if (b lt 1024) {
+				if(b eq int(b)) return trim(numberFormat(b,"9,999")) & " KB";
+				return trim(numberFormat(b,"9,999.9")) & " KB";
+			}
+			b= b / 1024;
+			if (b eq int(b)) return trim(numberFormat(b,"999,999,999")) & " MB";
+			return trim(numberFormat(b,"999,999,999.9")) & " MB";
+		}
+
+/* copied from soundings UDFs
+ to deal with the merging of the two apps
+*/
+		function arrayDefinedAt(arr,pos) {
+			var temp = "";
+			try {
+				temp = arr[pos];
+				return true;
+			}
+			catch(coldfusion.runtime.UndefinedElementException ex) {
+				return false;
+			}
+			catch(coldfusion.runtime.CfJspPage$ArrayBoundException ex) {
+				return false;
+			}
+		}
+		request.udf.arrayDefinedAt = arrayDefinedAt;
+
+	</cfscript>
+
+<!---
+	  This UDF from Steven Erat, http://www.talkingtree.com/blog
+--->
+	<cffunction name="replaceLinks" access="public" output="yes" returntype="string">
+		<cfargument name="input" required="Yes" type="string">
+		<cfargument name="linkmax" type="numeric" required="false" default="50">
+		<cfscript>
+			var inputReturn = arguments.input;
+			var pattern = "";
+			var urlMatches = structNew();
+			var inputCopy = arguments.input;
+			var result = "";
+			var rightStart = "";
+			var rightInputCopyLen = "";
+			var targetNameMax = "";
+			var targetLinkName = "";
+			var i = "";
+
+			pattern = "(((https?:|ftp:|gopher:)\/\/)|(www\.|ftp\.))[-[:alnum:]\?%,\.\/&##!;@:=\+~_]+[A-Za-z0-9\/]";
+
+			while (len(inputCopy)) {
+				result = refind(pattern,inputCopy,1,'true');
+				if (result.pos[1]){
+					match = mid(inputCopy,result.pos[1],result.len[1]);
+					urlMatches[match] = "";
+					rightStart = result.len[1] + result.pos[1];
+					rightInputCopyLen = len(inputCopy)-rightStart;
+					if (rightInputCopyLen GT 0){
+						inputCopy = right(inputCopy,rightInputCopyLen);
+					} else break;
+				} else break;
+			}
+
+//convert back to array
+			urlMatches = structKeyArray(urlMatches);
+
+			targetNameMax = arguments.linkmax;
+			for (i=1; i LTE arraylen(urlMatches);i=i+1) {
+				targetLinkName = urlMatches[i];
+				if (len(targetLinkName) GTE targetNameMax) {
+					targetLinkName = left(targetLinkName,targetNameMax) & "...";
+				}
+				inputReturn = replace(inputReturn,urlMatches[i],'<a href="#urlMatches[i]#" target="_blank">#targetLinkName#</a>',"all");
+			}
+		</cfscript>
+		<cfreturn inputReturn>
+	</cffunction>
+
+
+<!---- Modified from parseMySES function in parseses.cfm from BlogCFC; modified to be more generic and also moved to tag from script ---->
+	<cffunction name="parseSES" returntype="struct">
+		<cfset var urlVars=reReplaceNoCase(trim(cgi.path_info), '.+\.cfm/? *', '')>
+		<cfset var r = structNew()>
+		<cfset var theLen = listLen(urlVars,"/")>
+		<cfset var TempIndex = "">
+
+<!---- if the list length is 0 or the only element of the URL vars is the delimiter, return the empty struct ---->
+		<cfif (len(urlVars) is 0 or urlvars is "/")>
+			<cfreturn r>
+		</cfif>
+
+<!---- this is the new stuff --->
+		<cfloop from="1" to="#theLen#" index="TempIndex" step="2">
+<!--- the try catches URL variables that are off ---->
+			<cftry>
+				<cfset r[ListGetAt(urlVars,Tempindex,"/")] = ListGetAt(urlVars,Tempindex+1,"/")>
+				<cfcatch type="any">
+					<cfset r[ListGetAt(urlVars,Tempindex,"/")] = "">
+				</cfcatch>
+			</cftry>
+
+		</cfloop>
+
+		<cfreturn r>
+
+	</cffunction>
+
+
 </cfcomponent>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,19 @@
 **Updates to BlogCFC**
 
+
+**2018/12/28 Update 2**: 
+
+* Merged in my own BlogCFC Extension. 
+    * Created download tracker code for tracking and reporting on enclosure downloads
+    * Added a tableprefix= config property.  This is if you want to add a prefix to the table name and will be appended to all queries.  If you use this, then you won't be able to use the SQL Generate scripts or the install/update package.
+    * Added BlogDBName argument to blog.cfc init.  This refers to name of the blog in the database and allows you to use different db names in the config file vs the database.
+    * Added isAvailable argument to blog.cfc entryexists() and getEntry(). If passed in as true, will allow an entry to exist even if it is not available yet
+    * Tweaked RSS 2.0 generation to add media tags; I think this supports podcasting platforms other than iTunes.
+    * Added a bunch more functions to utils--don't remember what they are all used for.
+
+**ToDo**:
+I still need to add scripts for the relevant new tables info.
+
 **2018/12/28**: 
 
 Since the project hasn't had an update in ages, I probably won't bother to try to do PRs back to the main branch, but decided to stick with BlogCFC for the moment for my own personal blog.
@@ -17,3 +31,5 @@ I added a new property to the `blog.ini.cfm`:
     maxentriesadmin=10
     
 This allows you to show a different number of posts in the client UI compare to a different number of posts in the admin.
+
+


### PR DESCRIPTION
    * Created download tracker code for tracking and reporting on enclosure downloads
    * Added a tableprefix= config property.  This is if you want to add a prefix to the table name and will be appended to all queries.  If you use this, then you won't be able to use the SQL Generate scripts or the install/update package.
    * Added BlogDBName argument to blog.cfc init.  This refers to name of the blog in the database and allows you to use different db names in the config file vs the database.
    * Added isAvailable argument to blog.cfc entryexists() and getEntry(). If passed in as true, will allow an entry to exist even if it is not available yet
    * Tweaked RSS 2.0 generation to add media tags; I think this supports podcasting platforms other than iTunes.
    * Added a bunch more functions to utils--don't remember what they are all used for.